### PR TITLE
Fix verification workflow: public clone + working-directory

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,7 +38,7 @@ jobs:
           echo "Chains to verify: $CHAINS"
 
       - name: Clone euler-verifier
-        run: git clone --depth 1 https://x-access-token:${{ secrets.EULER_TOKEN }}@github.com/euler-xyz/euler-verifier.git /tmp/euler-verifier
+        run: git clone --depth 1 https://github.com/euler-xyz/euler-verifier.git /tmp/euler-verifier
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -49,7 +49,8 @@ jobs:
         run: pip install uv
 
       - name: Install dependencies
-        run: cd /tmp/euler-verifier && uv sync
+        working-directory: /tmp/euler-verifier
+        run: uv sync
 
       - name: Symlink euler-interfaces into verifier
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,7 +38,7 @@ jobs:
           echo "Chains to verify: $CHAINS"
 
       - name: Clone euler-verifier
-        run: git clone --depth 1 https://github.com/euler-xyz/euler-verifier.git /tmp/euler-verifier
+        run: git clone --depth 1 https://x-access-token:${{ secrets.EULER_TOKEN }}@github.com/euler-xyz/euler-verifier.git /tmp/euler-verifier
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
- Revert to plain HTTPS clone (euler-verifier is now public)
- Use `working-directory` for `uv sync` instead of `cd` (which doesn't persist in GitHub Actions)