### PR TITLE
Fix uv sync in verification workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: /tmp/euler-verifier
-        run: uv sync
+        run: uv sync --no-install-project
 
       - name: Symlink euler-interfaces into verifier
         run: |


### PR DESCRIPTION
Use --no-install-project to skip building the euler-verifier wheel (no euler_verifier package directory exists).