### PR TITLE
Add contract verification reports

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -108,3 +108,19 @@ jobs:
           name: verification-reports
           path: /tmp/euler-verifier/results/
           retention-days: 30
+
+      - name: Commit reports to verify/
+        run: |
+          cp /tmp/euler-verifier/results/*.md verify/ 2>/dev/null || true
+          rm -f verify/*_test.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add verify/
+          if git diff --staged --quiet; then
+            echo "No changes to verification reports"
+          else
+            git commit -m "Update verification reports [skip ci]"
+            git push
+          fi

--- a/verify/README.md
+++ b/verify/README.md
@@ -1,0 +1,51 @@
+# Euler Contract Verification Reports
+
+## Production Networks
+
+| Network | Chain ID | Status | Contracts | Notes |
+|---------|----------|--------|-----------|-------|
+| [Mainnet](mainnet.md) | 1 | ✅ 100% | 26/26 | |
+| [Arbitrum](arbitrum.md) | 42161 | ✅ 100% | 26/26 | |
+| [Base](base.md) | 8453 | ✅ 100% | 26/26 | |
+| [BSC](bsc.md) | 56 | ✅ 100% | 26/26 | |
+| [Avalanche](avalanche.md) | 43114 | ✅ 100% | 26/26 | |
+| [Linea](linea.md) | 59144 | ⚠️ 96% | 25/26 | eulerEarnFactory: 24KB optimizations |
+| [Swell](swell.md) | 1923 | ✅ 100% | 26/26 | |
+| [Sonic](sonic.md) | 146 | ✅ 100% | 26/26 | |
+| [Bob](bob.md) | 60808 | ✅ 100% | 26/26 | |
+| [Berachain](berachain.md) | 80094 | ✅ 100% | 26/26 | |
+| [Unichain](unichain.md) | 130 | ✅ 100% | 26/26 | |
+| [Monad](monad.md) | 143 | ✅ 100% | 21/21 | |
+| [TAC](tac.md) | 239 | ✅ 100% | 26/26 | |
+| [Plasma](plasma.md) | 9745 | ⚠️ 27% | 7/26 | Most contracts not verified on explorer |
+
+## Report Structure
+
+Each report contains:
+
+1. **Summary table** — all contracts with address, source repo, deployment commit, evk-periphery ref, and file match count
+2. **Changes Since Deployment** — diffs between the deployment commit and current `master`, scoped to only the files that are part of each deployed contract
+
+## Running Verification
+
+```bash
+# Verify a single network
+uv run python verify.py mainnet
+
+# Verify all production networks
+uv run python verify.py --all
+
+# Deep search through git history
+uv run python verify.py mainnet --exhaustive
+
+# List available networks
+uv run python verify.py --list
+```
+
+## Notes
+
+### Linea (96%)
+- **eulerEarnFactory**: Deployed with 24KB size optimizations (commented out `setName`/`setSymbol`)
+
+### Plasma (27%)
+- Most contracts are not yet verified on the Plasma block explorer

--- a/verify/arbitrum.md
+++ b/verify/arbitrum.md
@@ -1,0 +1,243 @@
+# Arbitrum Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x148B1DC3...`](https://arbiscan.io/address/0x148B1DC3168C73907D9F00165Ceab62Fd81f3E9D) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0xbCD29c1B...`](https://arbiscan.io/address/0xbCD29c1B596d9fFAfaa6F90780956b4D3d47832f) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0xB9B5d62B...`](https://arbiscan.io/address/0xB9B5d62B9fE9E1B505466e75817aB178A1D2ec9d) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x0161FE2C...`](https://arbiscan.io/address/0x0161FE2CA6ED39b5D0811a94b87AC628677Ae020) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x7949bE8B...`](https://arbiscan.io/address/0x7949bE8B154D7B5ce6E75cBfc646AeF3a25970E2) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x04671F89...`](https://arbiscan.io/address/0x04671F895c7d9EAbF33FF1dfF41269E6Fea835D1) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0x804485f5...`](https://arbiscan.io/address/0x804485f5B6c293f8d63f697E9662CD4a8765858A) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0x138AB9B3...`](https://arbiscan.io/address/0x138AB9B33741B25bb7BcDa466175c8B2E2b96dc4) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0xAF6412D5...`](https://arbiscan.io/address/0xAF6412D58024874b0Ffc4138FfF95fc73b372977) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0x223c1a20...`](https://arbiscan.io/address/0x223c1a20A6992a0F1E7066eD924619c3156DDA15) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0xA6fCC47f...`](https://arbiscan.io/address/0xA6fCC47f8D930f096F8749C7C7D335871bc71C0D) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0x99C341F0...`](https://arbiscan.io/address/0x99C341F07098ba70aC1130c479103Dc2366dbBD7) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0x174834a9...`](https://arbiscan.io/address/0x174834a9DE4C2f0c13c7353e62C229E8D607c808) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x78Df1CF5...`](https://arbiscan.io/address/0x78Df1CF5bf06a7f27f2ACc580B934238C1b80D50) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x832fF401...`](https://arbiscan.io/address/0x832fF4011A3164ea76ceA06A313EE0B6CD72ba96) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x6302ef0F...`](https://arbiscan.io/address/0x6302ef0F34100CDDFb5489fbcB6eE1AA95CD1066) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0xA1585dc7...`](https://arbiscan.io/address/0xA1585dc7Cd4EF33f7a855fDE39771b37838B0bFE) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0xe9625953...`](https://arbiscan.io/address/0xe962595391F481c4EB2cB8Adef7a064B1F76C36f) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x27369477...`](https://arbiscan.io/address/0x27369477130C8bC49CeeAe8ACb9cE50a2a7De616) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0xE055ea12...`](https://arbiscan.io/address/0xE055ea126c7704fFCf3Bd8a8F46aC93A6965560E) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 5/5 |
+| ✓ kinkyIRMFactory | [`0x1abB566e...`](https://arbiscan.io/address/0x1abB566e1cc1efd19594fF2dCF1219F71e06558A) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0x22d51Db4...`](https://arbiscan.io/address/0x22d51Db42A59862D4F8c135C4406AEf9854ABFF3) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x06c1Ab0A...`](https://arbiscan.io/address/0x06c1Ab0A1672E8FC7F7D10BD7B869B4116D18a2c) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0xFA31599a...`](https://arbiscan.io/address/0xFA31599a4928c2d57C0dd77DFCA5DA1E94E6D2D2) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0x924C73ab...`](https://arbiscan.io/address/0x924C73abAa350800fc22c11ffdFB09641106E3ce) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x7b16DAaF...`](https://arbiscan.io/address/0x7b16DAaFa76CfeC8C08D7a68aF31949B37ebfdF5) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** kinkIRMFactory, swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/IRMFactory/EulerKinkIRMFactory.sol b/src/IRMFactory/EulerKinkIRMFactory.sol
+index 2b651a40..1d7b8fbf 100644
+--- a/src/IRMFactory/EulerKinkIRMFactory.sol
++++ b/src/IRMFactory/EulerKinkIRMFactory.sol
+@@ -4,12 +4,13 @@ pragma solidity ^0.8.0;
+ 
+ import {BaseFactory} from "../BaseFactory/BaseFactory.sol";
+ import {IRMLinearKink} from "evk/InterestRateModels/IRMLinearKink.sol";
++import {IEulerKinkIRMFactory} from "./interfaces/IEulerKinkIRMFactory.sol";
+ 
+ /// @title EulerKinkIRMFactory
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+ /// @notice A minimal factory for Kink IRMs.
+-contract EulerKinkIRMFactory is BaseFactory {
++contract EulerKinkIRMFactory is BaseFactory, IEulerKinkIRMFactory {
+     // corresponds to 1000% APY
+     uint256 internal constant MAX_ALLOWED_INTEREST_RATE = 75986279153383989049;
+ 
+@@ -22,7 +23,11 @@ contract EulerKinkIRMFactory is BaseFactory {
+     /// @param slope2 Slope of the function after the kink
+     /// @param kink Utilization at which the slope of the interest rate function changes. In type(uint32).max scale
+     /// @return The deployment address.
+-    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink) external returns (address) {
++    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink)
++        external
++        override
++        returns (address)
++    {
+         IRMLinearKink irm = new IRMLinearKink(baseRate, slope1, slope2, kink);
+ 
+         // verify if the IRM is functional
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+```
+
+_Showing first 100 of 101 lines. [View full diff on GitHub](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)_
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/avalanche.md
+++ b/verify/avalanche.md
@@ -1,0 +1,210 @@
+# Avalanche Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x104BA4D7...`](https://snowtrace.io/address/0x104BA4D746cf71F23341a7c855271A5E7dD19F58) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0xAf565942...`](https://snowtrace.io/address/0xAf5659428FEF1F6a701FaB46d8f3aF8371A9913D) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0x574B00f5...`](https://snowtrace.io/address/0x574B00f5a0C56D370F19fa887a5545d74F52fAC2) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x2524762d...`](https://snowtrace.io/address/0x2524762ddb853AB1e572B81E5E6377a8a1536aA5) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x8A1D3a48...`](https://snowtrace.io/address/0x8A1D3a4850ed7deeC9003680Cf41b8E75D27e440) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x4F4FDeE3...`](https://snowtrace.io/address/0x4F4FDeE3568aC31C46634fb2Df3FF44A156Be351) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0x31F34124...`](https://snowtrace.io/address/0x31F34124a37f94efd17201A1B88d5008cD444c72) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0xd80e68B3...`](https://snowtrace.io/address/0xd80e68B39e4408cb7D6c8E3343Bde46587013F62) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x2836825d...`](https://snowtrace.io/address/0x2836825daeC3D5d8fD3ad71d61f72345bB868110) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0x4fef2f71...`](https://snowtrace.io/address/0x4fef2f7146c0b4e6C0b1433badC6B7a2E1E7ECDb) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0x1C0e8b84...`](https://snowtrace.io/address/0x1C0e8b841DA677C685D2a8376773e8A872C1ce5C) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0xF9f2dF8A...`](https://snowtrace.io/address/0xF9f2dF8A5Cc71a0424dfA9EbdfdfF8A082C19184) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0xF1A5F97A...`](https://snowtrace.io/address/0xF1A5F97AB84158Cf6d8ba8dEF68780Fc2Fd64310) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0xaf4B4c18...`](https://snowtrace.io/address/0xaf4B4c18B17F6a2B32F6c398a3910bdCD7f26181) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x29E9b639...`](https://snowtrace.io/address/0x29E9b639e165d919FEcf02521F8A9dA0492D4f21) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0xddcbe30A...`](https://snowtrace.io/address/0xddcbe30A761Edd2e19bba930A977475265F36Fa1) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0x95F21cD9...`](https://snowtrace.io/address/0x95F21cD90057BBdC6fAc3f9b94D06b53C24B278c) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x53A37B5d...`](https://snowtrace.io/address/0x53A37B5d8a30a49bCB463eF33d610d5E5040C64A) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0xcA14D397...`](https://snowtrace.io/address/0xcA14D397219808F39724607e6401bD8C46CbF65f) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0xcad49893...`](https://snowtrace.io/address/0xcad498936E09f38f18eD8375AeCD1d46689e7086) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ kinkyIRMFactory | [`0x34E21196...`](https://snowtrace.io/address/0x34E21196d7A303EE06c25aEF3B9CCD111c15c9aC) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0x80528F01...`](https://snowtrace.io/address/0x80528F014E84658e85D3C6D4896A29Fa933Be696) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x8564160f...`](https://snowtrace.io/address/0x8564160f30926eA1229DCcf24118c6De155D2e30) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0x2e3b3273...`](https://snowtrace.io/address/0x2e3b32730B4F6b6502BdAa9122df3B026eDE5391) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0x9C38f923...`](https://snowtrace.io/address/0x9C38f923baC407C818312EADEf69AdC116fd16FD) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x0d7938D9...`](https://snowtrace.io/address/0x0d7938D9c31Cd7dD693752074284af133c1142de) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+     /// @param account User account to query
+```
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/base.md
+++ b/verify/base.md
@@ -1,0 +1,280 @@
+# Base Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0xae752d78...`](https://basescan.org/address/0xae752d786ecAf6683f61b7D910F221edD003895b) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0x029fDEe8...`](https://basescan.org/address/0x029fDEe85BEdB0553D6fdc538546586641DD7438) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`8695c72c`](https://github.com/euler-xyz/evk-periphery/tree/8695c72c) | 17/17 |
+| ✓ eulerEarnFactory | [`0x75F49a26...`](https://basescan.org/address/0x75F49a2621b6DeC6a5baB22ce961bF3e676EFAE6) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x0dFFc3A5...`](https://basescan.org/address/0x0dFFc3A53693bCd8e42FAd9be94fB8f1Fb64A8EE) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0xf0CFe22d...`](https://basescan.org/address/0xf0CFe22d23699ff1B2CFe6B8f706A6DB63911262) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x3Ce63C16...`](https://basescan.org/address/0x3Ce63C16CB719a0c755DA25cd5dD35170A00424f) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0x18e5F5C1...`](https://basescan.org/address/0x18e5F5C1ff5e905b32CE860576031AE90E1d1336) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0x6C5f4c23...`](https://basescan.org/address/0x6C5f4c239ceD289447737EAB8eEA64523bd9c05E) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x6F1C1a3e...`](https://basescan.org/address/0x6F1C1a3eAFbB1b345AD5662b0374a9Bf0E4785af) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0xA564dAe6...`](https://basescan.org/address/0xA564dAe65eA7B1ce049AbACFC4Cb1A32C93e127c) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0x78bCCFA3...`](https://basescan.org/address/0x78bCCFA312432cE84d0B818796eE33f9192A284d) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0x35D410A5...`](https://basescan.org/address/0x35D410A5052c7362eCdD72cFb65651A71adFaf61) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0x9ff7ea0C...`](https://basescan.org/address/0x9ff7ea0Cf94b8665c2F5d17560Bd34Ab9BbAcd21) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x7F321498...`](https://basescan.org/address/0x7F321498A801A191a93C840750ed637149dDf8D0) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x30a9A965...`](https://basescan.org/address/0x30a9A9654804F1e5b3291a86E83EdeD7cF281618) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`9e3c760e`](https://github.com/euler-xyz/euler-vault-kit/tree/9e3c760e051f5d769f7c6edb9be30198a55117d4) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 52/52 |
+| ✓ evc | [`0x5301c7dD...`](https://basescan.org/address/0x5301c7dD20bD945D2013b48ed0DEE3A284ca8989) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0xbF4906E2...`](https://basescan.org/address/0xbF4906E2F20362c3d746F7eFfF54abB8282902ed) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0xf44333b5...`](https://basescan.org/address/0xf44333b5A3EB4D069AB8Bb6FEc88225d8eE5d2bB) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x424d5C3e...`](https://basescan.org/address/0x424d5C3e0046168C2F193Aa939c7a9aaB01eeB9A) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x2d94C898...`](https://basescan.org/address/0x2d94C898a17f9D8c0bA75010A51cd61BF55b402E) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 5/5 |
+| ✓ kinkyIRMFactory | [`0x9907E7F6...`](https://basescan.org/address/0x9907E7F6637B161c19c08cc716C23f53b49C9Ec2) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0xA9287853...`](https://basescan.org/address/0xA9287853987B107969f181Cce5e25e0D09c1c116) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x1D4b9e6A...`](https://basescan.org/address/0x1D4b9e6ACACdc82Dd9E903C3F4431558Af32C4A9) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0xE08e1f00...`](https://basescan.org/address/0xE08e1f00D388E201e48842E53fA96195568e6813) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0xfE9011FD...`](https://basescan.org/address/0xfE9011FD097cd35866b9e4740BBC88B4ef26E3ba) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x30660764...`](https://basescan.org/address/0x30660764A7a05B84608812C8AFC0Cb4845439EEe) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `9e3c760e`
+
+**Contracts:** eVaultImplementation
+
+- **Deployed from:** [`9e3c760e`](https://github.com/euler-xyz/euler-vault-kit/tree/9e3c760e)
+- **Compare to master:** [`9e3c760e...master`](https://github.com/euler-xyz/euler-vault-kit/compare/9e3c760e...master)
+- **evk-periphery:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+
+```diff
+diff --git a/src/EVault/modules/Governance.sol b/src/EVault/modules/Governance.sol
+index 5c728ed..08c5c96 100644
+--- a/src/EVault/modules/Governance.sol
++++ b/src/EVault/modules/Governance.sol
+@@ -290,7 +290,7 @@ abstract contract GovernanceModule is IGovernance, BalanceUtils, BorrowUtils, LT
+         ConfigAmount newBorrowLTV = borrowLTV.toConfigAmount();
+         ConfigAmount newLiquidationLTV = liquidationLTV.toConfigAmount();
+ 
+-        // The borrow LTV must be lower than or equal to the the converged liquidation LTV
++        // The borrow LTV must be lower than or equal to the converged liquidation LTV
+         if (newBorrowLTV > newLiquidationLTV) revert E_LTVBorrow();
+ 
+         LTVConfig memory currentLTV = vaultStorage.ltvLookup[collateral];
+@@ -304,12 +304,6 @@ abstract contract GovernanceModule is IGovernance, BalanceUtils, BorrowUtils, LT
+ 
+         if (!currentLTV.isRecognizedCollateral()) vaultStorage.ltvList.push(collateral);
+ 
+-        if (!newLiquidationLTV.isZero()) {
+-            // Ensure that this collateral can be priced by the configured oracle
+-            (, IPriceOracle _oracle, address _unitOfAccount) = ProxyUtils.metadata();
+-            _oracle.getQuote(1e18, collateral, _unitOfAccount);
+-        }
+-
+         emit GovSetLTV(
+             collateral,
+             newLTV.borrowLTV.toUint16(),
+```
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** kinkIRMFactory, swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/IRMFactory/EulerKinkIRMFactory.sol b/src/IRMFactory/EulerKinkIRMFactory.sol
+index 2b651a40..1d7b8fbf 100644
+--- a/src/IRMFactory/EulerKinkIRMFactory.sol
++++ b/src/IRMFactory/EulerKinkIRMFactory.sol
+@@ -4,12 +4,13 @@ pragma solidity ^0.8.0;
+ 
+ import {BaseFactory} from "../BaseFactory/BaseFactory.sol";
+ import {IRMLinearKink} from "evk/InterestRateModels/IRMLinearKink.sol";
++import {IEulerKinkIRMFactory} from "./interfaces/IEulerKinkIRMFactory.sol";
+ 
+ /// @title EulerKinkIRMFactory
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+ /// @notice A minimal factory for Kink IRMs.
+-contract EulerKinkIRMFactory is BaseFactory {
++contract EulerKinkIRMFactory is BaseFactory, IEulerKinkIRMFactory {
+     // corresponds to 1000% APY
+     uint256 internal constant MAX_ALLOWED_INTEREST_RATE = 75986279153383989049;
+ 
+@@ -22,7 +23,11 @@ contract EulerKinkIRMFactory is BaseFactory {
+     /// @param slope2 Slope of the function after the kink
+     /// @param kink Utilization at which the slope of the interest rate function changes. In type(uint32).max scale
+     /// @return The deployment address.
+-    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink) external returns (address) {
++    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink)
++        external
++        override
++        returns (address)
++    {
+         IRMLinearKink irm = new IRMLinearKink(baseRate, slope1, slope2, kink);
+ 
+         // verify if the IRM is functional
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+```
+
+_Showing first 100 of 101 lines. [View full diff on GitHub](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)_
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`8695c72c`](https://github.com/euler-xyz/evk-periphery/tree/8695c72c)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/berachain.md
+++ b/verify/berachain.md
@@ -1,0 +1,322 @@
+# Berachain Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0xc6e28b94...`](https://berascan.com/address/0xc6e28b94737f664b0be4230bd86793B6B6ed973B) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0x70Fb24bD...`](https://berascan.com/address/0x70Fb24bDa46E7cFD447C64bB32180Bc746ba3A71) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0x9cbc3030...`](https://berascan.com/address/0x9cbc3030e6d133D1AAa148D598FD82D70263495c) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x4E7C0590...`](https://berascan.com/address/0x4E7C059099496D56e8662570426991EA63C63C85) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0xD14c95dc...`](https://berascan.com/address/0xD14c95dc228E8851F63d9b83A0001F4D021B5DFf) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x0e05d236...`](https://berascan.com/address/0x0e05d236cb6c350935751A73e834A13111998e3c) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0x46F95127...`](https://berascan.com/address/0x46F951278f52f4798542C51BfB8Df1c165199150) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0x1A4546b9...`](https://berascan.com/address/0x1A4546b988Ee133F72b7E27a4890355b0a341554) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x9253a3EF...`](https://berascan.com/address/0x9253a3EF2cE8875b7D15Bd2bcd3a405b62a7b0E7) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0x5e044DB2...`](https://berascan.com/address/0x5e044DB2Fd14fbB48334b239CfD8530C9b03150B) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0xAe26ca82...`](https://berascan.com/address/0xAe26ca82da91a1157E3cC0B36a9A06f539f4DF24) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0x8D8B81F0...`](https://berascan.com/address/0x8D8B81F0c1be01fa3636d2cD6DeF07474d75e1e9) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0xc1d31b28...`](https://berascan.com/address/0xc1d31b2812Cc920341349a717d14bAdFb1BCab11) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x5C13fb43...`](https://berascan.com/address/0x5C13fb43ae9BAe8470f646ea647784534E9543AF) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x402598Ac...`](https://berascan.com/address/0x402598Ac4034D24f2cB37BDb0721A67365aD19BD) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x45334608...`](https://berascan.com/address/0x45334608ECE7B2775136bC847EB92B5D332806A9) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0x5EAe58dc...`](https://berascan.com/address/0x5EAe58dc72E4E374F32eCA2751cC38b573dd82c9) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x664a67B5...`](https://berascan.com/address/0x664a67B5D4e53B8A0eab1421EEe2b7097a5523d1) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x3e3eD6B4...`](https://berascan.com/address/0x3e3eD6B48B7fBD2518019CE53bbB02048E56f265) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0xeAF2a39A...`](https://berascan.com/address/0xeAF2a39A6D1A4C9b00Aca48eCE42C044A5a9628a) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ kinkyIRMFactory | [`0xE43Aa2a0...`](https://berascan.com/address/0xE43Aa2a0bee4dd4C88148e1C459ee0323d4CAf22) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0x809aB347...`](https://berascan.com/address/0x809aB347e6ECb46714917A7796E542c86f75FbF1) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x51432af6...`](https://berascan.com/address/0x51432af61A715DB3D0f20A3691C1E25F9A2c6B05) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0x56C44d2F...`](https://berascan.com/address/0x56C44d2F484A61ce92Fa0BCc849feB37aBfeB59C) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0x0c9a75E0...`](https://berascan.com/address/0x0c9a75E05764775A0cF52bC6cbfE6Cb229bb3901) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x6fFf8Ac4...`](https://berascan.com/address/0x6fFf8Ac4AB123B62FF5e92aBb9fF702DCBD6C939) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-earn @ `773453b`
+
+**Contracts:** eulerEarnFactory
+
+- **Deployed from:** [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b)
+- **Compare to master:** [`773453b...master`](https://github.com/euler-xyz/euler-earn/compare/773453b...master)
+
+```diff
+diff --git a/src/EulerEarn.sol b/src/EulerEarn.sol
+index 4635a89..27c1873 100644
+--- a/src/EulerEarn.sol
++++ b/src/EulerEarn.sol
+@@ -17,12 +17,12 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ import {EventsLib} from "./libraries/EventsLib.sol";
+ import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
+ import {UtilsLib, WAD} from "./libraries/UtilsLib.sol";
+-import {SafeCast} from "../lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+-import {IERC20Metadata} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
++import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
++import {IERC20Metadata} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Metadata.sol";
+ 
+-import {Context} from "../lib/openzeppelin-contracts/contracts/utils/Context.sol";
+-import {ReentrancyGuard} from "../lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+-import {Ownable2Step, Ownable} from "../lib/openzeppelin-contracts/contracts/access/Ownable2Step.sol";
++import {Context} from "openzeppelin-contracts/utils/Context.sol";
++import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
++import {Ownable2Step, Ownable} from "openzeppelin-contracts/access/Ownable2Step.sol";
+ import {
+     IERC20,
+     IERC4626,
+@@ -30,8 +30,8 @@ import {
+     ERC4626,
+     Math,
+     SafeERC20
+-} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++} from "openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarn
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/EulerEarnFactory.sol b/src/EulerEarnFactory.sol
+index 758185e..e7fd335 100644
+--- a/src/EulerEarnFactory.sol
++++ b/src/EulerEarnFactory.sol
+@@ -10,8 +10,8 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ 
+ import {EulerEarn} from "./EulerEarn.sol";
+ 
+-import {Ownable, Context} from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++import {Ownable, Context} from "openzeppelin-contracts/access/Ownable.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarnFactory
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/interfaces/IEulerEarn.sol b/src/interfaces/IEulerEarn.sol
+index 27334f2..ed18e7e 100644
+--- a/src/interfaces/IEulerEarn.sol
++++ b/src/interfaces/IEulerEarn.sol
+@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
+ 
+ import {IEulerEarnFactory} from "./IEulerEarnFactory.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+-import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
++import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
+ 
+ import {MarketConfig, PendingUint136, PendingAddress} from "../libraries/PendingLib.sol";
+ 
+diff --git a/src/interfaces/IPublicAllocator.sol b/src/interfaces/IPublicAllocator.sol
+index b222ce3..4a9067b 100644
+--- a/src/interfaces/IPublicAllocator.sol
++++ b/src/interfaces/IPublicAllocator.sol
+@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
+ 
+ import {MarketAllocation} from "./IEulerEarn.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @dev Max settable flow cap, such that caps can always be stored on 128 bits.
+ /// @dev The actual max possible flow cap is type(uint128).max-1.
+diff --git a/src/libraries/ErrorsLib.sol b/src/libraries/ErrorsLib.sol
+index 300bb22..da0feca 100644
+--- a/src/libraries/ErrorsLib.sol
++++ b/src/libraries/ErrorsLib.sol
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ pragma solidity ^0.8.0;
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @title ErrorsLib
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/libraries/EventsLib.sol b/src/libraries/EventsLib.sol
+index f9dc967..862b344 100644
+--- a/src/libraries/EventsLib.sol
++++ b/src/libraries/EventsLib.sol
+@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
+ 
+ import {FlowCapsConfig} from "../interfaces/IPublicAllocator.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+```
+
+_Showing first 100 of 117 lines. [View full diff on GitHub](https://github.com/euler-xyz/euler-earn/compare/773453b...master)_
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+     /// @param account User account to query
+```
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/bob.md
+++ b/verify/bob.md
@@ -1,0 +1,355 @@
+# BOB Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0xd399A495...`](https://explorer.gobob.xyz/address/0xd399A4952A2444d20Fe97C5EdB5465Ad5dBaCe0d) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0x5a3828be...`](https://explorer.gobob.xyz/address/0x5a3828beA292E5f29725Fa449F9113Cb5E60ADF8) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0x8F01c664...`](https://explorer.gobob.xyz/address/0x8F01c6640A1c0a6085C79843F861fF0F89b9fED6) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0xB5Daee4a...`](https://explorer.gobob.xyz/address/0xB5Daee4a8AD1388B3D72C1367b8BA63DfB4AAbf5) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0xE25B3cdA...`](https://explorer.gobob.xyz/address/0xE25B3cdA6fccAcbD794aEA64eE1B496d7b441644) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x334eac29...`](https://explorer.gobob.xyz/address/0x334eac29ffAc27E6BC3484A738DAf520359698F0) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0x199cC7C8...`](https://explorer.gobob.xyz/address/0x199cC7C8606088bc22D82CDae2D7EE7F5F99ec9F) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0xa077991e...`](https://explorer.gobob.xyz/address/0xa077991e2929d97f29fE39372E736FC118a4FAd3) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x90bd38E8...`](https://explorer.gobob.xyz/address/0x90bd38E89726BdCf42E07D88B23c2A493cb3877a) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0xaEAab95e...`](https://explorer.gobob.xyz/address/0xaEAab95eE90196E20fD2a5348643cCa0EF2b038e) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0x6e5dF960...`](https://explorer.gobob.xyz/address/0x6e5dF960eccD2Bf8818526A88f6E7da99a5379d7) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0xf33F4e20...`](https://explorer.gobob.xyz/address/0xf33F4e20905801D55531b38749727954D0152d3D) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0x797964F9...`](https://explorer.gobob.xyz/address/0x797964F9eB3A733D443810820f56c9ebAab1d1c2) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x046a9837...`](https://explorer.gobob.xyz/address/0x046a9837A61d6b6263f54F4E27EE072bA4bdC7e4) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x32CFc569...`](https://explorer.gobob.xyz/address/0x32CFc56917C0025501b34C43f7FE767Ef1EDE3a2) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x59f0FeEc...`](https://explorer.gobob.xyz/address/0x59f0FeEc4fA474Ad4ffC357cC8d8595B68abE47d) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0xcb3c0D13...`](https://explorer.gobob.xyz/address/0xcb3c0D131C64265099868F847face425499785A8) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0xb6b61828...`](https://explorer.gobob.xyz/address/0xb6b61828bf5E28193E58837174Af037848dEa6d5) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0xD9FA1867...`](https://explorer.gobob.xyz/address/0xD9FA1867066C3cDc50aC877FeDf505Eb2FC64dd7) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x4464a3FD...`](https://explorer.gobob.xyz/address/0x4464a3FD2A08b74324ecabA3149df421Dda3D0D0) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 5/5 |
+| ✓ kinkyIRMFactory | [`0x3d21D77D...`](https://explorer.gobob.xyz/address/0x3d21D77Dd3e825a1DaDc4494A4b328613e04fa30) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0xEFCF1F2f...`](https://explorer.gobob.xyz/address/0xEFCF1F2f09163e3813f5C16346A9F2Aa21ABA74d) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x94047C7d...`](https://explorer.gobob.xyz/address/0x94047C7daF06a6DE4049365cFa95fb4389a6F9Fe) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0x9f395F61...`](https://explorer.gobob.xyz/address/0x9f395F610Af9ffC98693A0769190446180dc7192) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0xf4C09771...`](https://explorer.gobob.xyz/address/0xf4C097718c64B6B0A75Cd9e0EF348fD6F176bE67) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x296041Db...`](https://explorer.gobob.xyz/address/0x296041DbdBC92171293F23c0a31e1574b791060d) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-earn @ `773453b`
+
+**Contracts:** eulerEarnFactory
+
+- **Deployed from:** [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b)
+- **Compare to master:** [`773453b...master`](https://github.com/euler-xyz/euler-earn/compare/773453b...master)
+
+```diff
+diff --git a/src/EulerEarn.sol b/src/EulerEarn.sol
+index 4635a89..27c1873 100644
+--- a/src/EulerEarn.sol
++++ b/src/EulerEarn.sol
+@@ -17,12 +17,12 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ import {EventsLib} from "./libraries/EventsLib.sol";
+ import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
+ import {UtilsLib, WAD} from "./libraries/UtilsLib.sol";
+-import {SafeCast} from "../lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+-import {IERC20Metadata} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
++import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
++import {IERC20Metadata} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Metadata.sol";
+ 
+-import {Context} from "../lib/openzeppelin-contracts/contracts/utils/Context.sol";
+-import {ReentrancyGuard} from "../lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+-import {Ownable2Step, Ownable} from "../lib/openzeppelin-contracts/contracts/access/Ownable2Step.sol";
++import {Context} from "openzeppelin-contracts/utils/Context.sol";
++import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
++import {Ownable2Step, Ownable} from "openzeppelin-contracts/access/Ownable2Step.sol";
+ import {
+     IERC20,
+     IERC4626,
+@@ -30,8 +30,8 @@ import {
+     ERC4626,
+     Math,
+     SafeERC20
+-} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++} from "openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarn
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/EulerEarnFactory.sol b/src/EulerEarnFactory.sol
+index 758185e..e7fd335 100644
+--- a/src/EulerEarnFactory.sol
++++ b/src/EulerEarnFactory.sol
+@@ -10,8 +10,8 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ 
+ import {EulerEarn} from "./EulerEarn.sol";
+ 
+-import {Ownable, Context} from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++import {Ownable, Context} from "openzeppelin-contracts/access/Ownable.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarnFactory
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/interfaces/IEulerEarn.sol b/src/interfaces/IEulerEarn.sol
+index 27334f2..ed18e7e 100644
+--- a/src/interfaces/IEulerEarn.sol
++++ b/src/interfaces/IEulerEarn.sol
+@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
+ 
+ import {IEulerEarnFactory} from "./IEulerEarnFactory.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+-import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
++import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
+ 
+ import {MarketConfig, PendingUint136, PendingAddress} from "../libraries/PendingLib.sol";
+ 
+diff --git a/src/interfaces/IPublicAllocator.sol b/src/interfaces/IPublicAllocator.sol
+index b222ce3..4a9067b 100644
+--- a/src/interfaces/IPublicAllocator.sol
++++ b/src/interfaces/IPublicAllocator.sol
+@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
+ 
+ import {MarketAllocation} from "./IEulerEarn.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @dev Max settable flow cap, such that caps can always be stored on 128 bits.
+ /// @dev The actual max possible flow cap is type(uint128).max-1.
+diff --git a/src/libraries/ErrorsLib.sol b/src/libraries/ErrorsLib.sol
+index 300bb22..da0feca 100644
+--- a/src/libraries/ErrorsLib.sol
++++ b/src/libraries/ErrorsLib.sol
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ pragma solidity ^0.8.0;
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @title ErrorsLib
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/libraries/EventsLib.sol b/src/libraries/EventsLib.sol
+index f9dc967..862b344 100644
+--- a/src/libraries/EventsLib.sol
++++ b/src/libraries/EventsLib.sol
+@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
+ 
+ import {FlowCapsConfig} from "../interfaces/IPublicAllocator.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+```
+
+_Showing first 100 of 117 lines. [View full diff on GitHub](https://github.com/euler-xyz/euler-earn/compare/773453b...master)_
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** kinkIRMFactory, swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/IRMFactory/EulerKinkIRMFactory.sol b/src/IRMFactory/EulerKinkIRMFactory.sol
+index 2b651a40..1d7b8fbf 100644
+--- a/src/IRMFactory/EulerKinkIRMFactory.sol
++++ b/src/IRMFactory/EulerKinkIRMFactory.sol
+@@ -4,12 +4,13 @@ pragma solidity ^0.8.0;
+ 
+ import {BaseFactory} from "../BaseFactory/BaseFactory.sol";
+ import {IRMLinearKink} from "evk/InterestRateModels/IRMLinearKink.sol";
++import {IEulerKinkIRMFactory} from "./interfaces/IEulerKinkIRMFactory.sol";
+ 
+ /// @title EulerKinkIRMFactory
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+ /// @notice A minimal factory for Kink IRMs.
+-contract EulerKinkIRMFactory is BaseFactory {
++contract EulerKinkIRMFactory is BaseFactory, IEulerKinkIRMFactory {
+     // corresponds to 1000% APY
+     uint256 internal constant MAX_ALLOWED_INTEREST_RATE = 75986279153383989049;
+ 
+@@ -22,7 +23,11 @@ contract EulerKinkIRMFactory is BaseFactory {
+     /// @param slope2 Slope of the function after the kink
+     /// @param kink Utilization at which the slope of the interest rate function changes. In type(uint32).max scale
+     /// @return The deployment address.
+-    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink) external returns (address) {
++    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink)
++        external
++        override
++        returns (address)
++    {
+         IRMLinearKink irm = new IRMLinearKink(baseRate, slope1, slope2, kink);
+ 
+         // verify if the IRM is functional
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+```
+
+_Showing first 100 of 101 lines. [View full diff on GitHub](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)_
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/bsc.md
+++ b/verify/bsc.md
@@ -1,0 +1,210 @@
+# BSC Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x6155921D...`](https://bscscan.com/address/0x6155921DaEa6a8Dca108c4B434bC66E1c51F6d6E) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0x2D13C46F...`](https://bscscan.com/address/0x2D13C46FE6c8B6c9ad3C5A78eD51b26733caE350) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0xc456d04E...`](https://bscscan.com/address/0xc456d04E3F43597CC7E5a2AF284fF4C4AdDA0cb1) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0xD5614794...`](https://bscscan.com/address/0xD561479477b03720bF485e91B76574374A646531) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x3e378e5E...`](https://bscscan.com/address/0x3e378e5E339DF5e0Da32964F9EEC2CDb90D28Cc7) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x16BCa432...`](https://bscscan.com/address/0x16BCa43290b77409e6D1c92B929f7A09C0E4EE86) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0xa8826Bb2...`](https://bscscan.com/address/0xa8826Bb29f875Db4c4b482463961776390774525) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0xA1F83E3d...`](https://bscscan.com/address/0xA1F83E3d1819C912122A1582B4B6D3d2a1E83bb7) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x90Cb0b67...`](https://bscscan.com/address/0x90Cb0b67f189a3D914DA00f72070531152DBc85F) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0x4258A349...`](https://bscscan.com/address/0x4258A34923CccFa29948881Cf6Aa8FdAD6338485) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0x71dFB713...`](https://bscscan.com/address/0x71dFB7138192B19CDc73487212bf6BB1Ffe3b9A1) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0xBc0f4dd9...`](https://bscscan.com/address/0xBc0f4dd9B5A10b15e6fA65e939Dbb1f98E7B08B7) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0x16332693...`](https://bscscan.com/address/0x1633269308F154fbECBb15F91d72D2aFA6af95B4) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x7F53E275...`](https://bscscan.com/address/0x7F53E2755eB3c43824E162F7F6F087832B9C9Df6) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0xB236413f...`](https://bscscan.com/address/0xB236413f1A8Fd4C5D5545ecAaC5e64fF686afe4e) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0xb2E5a73C...`](https://bscscan.com/address/0xb2E5a73CeE08593d1a076a2AE7A6e02925a640ea) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0xE7Ef8C7C...`](https://bscscan.com/address/0xE7Ef8C7CcB6aa81e366f0A0ccd89A298d9893E83) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x5151a812...`](https://bscscan.com/address/0x5151a8125B91A220fFe8fEA2Ab2815b46ecaAfFb) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x71620376...`](https://bscscan.com/address/0x71620376630597FA901112821455814a31d39685) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x40739156...`](https://bscscan.com/address/0x40739156B75b477f5b4f2D671655492B535B59d2) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ kinkyIRMFactory | [`0x996E67A0...`](https://bscscan.com/address/0x996E67A00D2dd4e2Ace3c507250524aC66438254) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0xbe83f65e...`](https://bscscan.com/address/0xbe83f65e5e898D482FfAEA251B62647c411576F1) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0xF524F75a...`](https://bscscan.com/address/0xF524F75ad063919B86d6c5D9242847A44337BFCe) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0x5e13d419...`](https://bscscan.com/address/0x5e13d41913aDF18bb2acAe34228E8D21f3c2f2Eb) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0x7fD287B3...`](https://bscscan.com/address/0x7fD287B3AE3Bf2F6C9871a44b6d9de208B0ABBE5) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0xA8a4f96E...`](https://bscscan.com/address/0xA8a4f96EC451f39Eb95913459901f39F5E1C068B) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+     /// @param account User account to query
+```
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/linea.md
+++ b/verify/linea.md
@@ -1,0 +1,338 @@
+# Linea Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 25 |
+| ✗ No exact commit found | 1 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0xc65a0e2a...`](https://lineascan.build/address/0xc65a0e2a410Ca52B0a5b57b1d239a857b3cd618b) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0xB9E491A3...`](https://lineascan.build/address/0xB9E491A3BB9d4B155d31a9cA6B9dE245CA16AAe6) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✗ eulerEarnFactory | [`0x377879A0...`](https://lineascan.build/address/0x377879A039343FEc7564e54616e519328951DA6D) | [euler-earn](https://github.com/euler-xyz/euler-earn) | not found | - | 33/35 |
+| ✓ eulerEarnPublicAllocator | [`0x4148f90e...`](https://lineascan.build/address/0x4148f90e03facFF8D2d5EFb475E36F94b4Ab4994) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`deployment-script`](https://github.com/euler-xyz/euler-earn/tree/deployment-script) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x970B065B...`](https://lineascan.build/address/0x970B065B572CC0118535Ad1101663CDBE7Db1e21) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`b948f405`](https://github.com/euler-xyz/euler-swap/tree/b948f4052d7ab3116235ec754368b7125dbd5082) | - | 57/57 |
+| ✓ eulerSwapV1Implementation | [`0x2b07caff...`](https://lineascan.build/address/0x2b07caff83C15c5a70C4C0867DFE7A0BE01025B0) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`b948f405`](https://github.com/euler-xyz/euler-swap/tree/b948f4052d7ab3116235ec754368b7125dbd5082) | - | 48/48 |
+| ✓ eulerSwapV1Periphery | [`0x0de305aB...`](https://lineascan.build/address/0x0de305aB93902914909951A00079ea1df3FD98eA) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`b948f405`](https://github.com/euler-xyz/euler-swap/tree/b948f4052d7ab3116235ec754368b7125dbd5082) | - | 11/11 |
+| ✓ eulerSwapV2Factory | [`0xB0cc1D8e...`](https://lineascan.build/address/0xB0cc1D8e6fAc157c76d2c08B7D55Eca1573BcBDF) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x476A2ad4...`](https://lineascan.build/address/0x476A2ad4a7c5Ac4DF1CaA429Cb70db865A160c11) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0x57729d78...`](https://lineascan.build/address/0x57729d78650cA751C9dB41f2536cA86da0032351) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0xe3ac3685...`](https://lineascan.build/address/0xe3ac3685D607308D4b4e26546EaDf675c37dd3dE) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0xEA3050E8...`](https://lineascan.build/address/0xEA3050E8A25f56AD0dbc90C3dCf016d8f5EfFE25) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0xd048d4e3...`](https://lineascan.build/address/0xd048d4e39e13482ECcE115E7BB71128d26ca19f1) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x84711986...`](https://lineascan.build/address/0x84711986Fd3BF0bFe4a8e6d7f4E22E67f7f27F04) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x58270C41...`](https://lineascan.build/address/0x58270C41552Bb2bef3Dc4e103b6f0c226032f007) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0xd8CeCEe9...`](https://lineascan.build/address/0xd8CeCEe9A04eA3d941a959F68fb4486f23271d09) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0xbF939812...`](https://lineascan.build/address/0xbF939812A673CB088f466d610c4b120b13eA5fAB) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x13697701...`](https://lineascan.build/address/0x13697701ff322367417469AB0497ea9C38b8A875) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x1Fa52975...`](https://lineascan.build/address/0x1Fa5297507c725f91479f3fa033a81c7f2E2d52D) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x2940Df42...`](https://lineascan.build/address/0x2940Df424dBDc697de86212eAb665721B6d32338) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ kinkyIRMFactory | [`0x054bF58e...`](https://lineascan.build/address/0x054bF58ec4531D6be9674558871f89C5867c6BfB) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0xf0125F63...`](https://lineascan.build/address/0xf0125F638c7134e6997e4F825b78c324CcF289aF) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x91868601...`](https://lineascan.build/address/0x91868601df03ED8E134EaAaB5E06F7183CC8383f) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0xe15C5F31...`](https://lineascan.build/address/0xe15C5F31cd7B767883F5654CDD3aFac28966B0a9) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0xcB1bB0A8...`](https://lineascan.build/address/0xcB1bB0A8A7ddeb09983dC1e7F880DCEdc39362BA) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x77C9B0E7...`](https://lineascan.build/address/0x77C9B0E7Ac0405797F04E5230Ed0A54DB39f98f0) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Contracts Without Exact Match
+
+These contracts could not be matched to any commit in the repository.
+Showing diff between explorer source and current `master`:
+
+### eulerEarnFactory
+
+- **Address:** [`0x377879A039343FEc7564e54616e519328951DA6D`](https://lineascan.build/address/0x377879A039343FEc7564e54616e519328951DA6D)
+- **Files matching:** 33/35
+
+```diff
+--- local/src/interfaces/IEulerEarn.sol
++++ explorer/src/interfaces/IEulerEarn.sol
+@@ -120,10 +120,10 @@
+     function revokePendingMarketRemoval(IERC4626 id) external;
+ 
+     /// @notice Sets the name of the Earn vault.
+-    function setName(string memory newName) external;
++    //function setName(string memory newName) external;
+ 
+     /// @notice Sets the symbol of the Earn vault.
+-    function setSymbol(string memory newSymbol) external;
++    //function setSymbol(string memory newSymbol) external;
+ 
+     /// @notice Submits a `newGuardian`.
+     /// @notice Warning: a malicious guardian could disrupt the Earn vault's operation, and would have the power to revoke
+--- local/src/EulerEarn.sol
++++ explorer/src/EulerEarn.sol
+@@ -190,7 +190,8 @@
+     }
+ 
+     /* ONLY OWNER FUNCTIONS */
+-
++// commented out not to exceed 24kB limit
++/*
+     /// @inheritdoc IEulerEarnBase
+     function setName(string memory newName) external onlyOwner {
+         _name = newName;
+@@ -204,7 +205,7 @@
+ 
+         emit EventsLib.SetSymbol(newSymbol);
+     }
+-
++*/
+     /// @inheritdoc IEulerEarnBase
+     function setCurator(address newCurator) external onlyOwner {
+         if (newCurator == curator) revert ErrorsLib.AlreadySet();
+```
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-earn @ `deployment-script`
+
+**Contracts:** eulerEarnPublicAllocator
+
+- **Deployed from:** [`deployment-script`](https://github.com/euler-xyz/euler-earn/tree/deployment-script)
+- **Compare to master:** [`deployment-script...master`](https://github.com/euler-xyz/euler-earn/compare/deployment-script...master)
+
+```diff
+diff --git a/src/PublicAllocator.sol b/src/PublicAllocator.sol
+index f71306c..9527976 100644
+--- a/src/PublicAllocator.sol
++++ b/src/PublicAllocator.sol
+@@ -14,8 +14,8 @@ import {IEulerEarn, MarketAllocation} from "./interfaces/IEulerEarn.sol";
+ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ import {EventsLib} from "./libraries/EventsLib.sol";
+ 
+-import {IERC4626} from "../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title PublicAllocator
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/interfaces/IEulerEarn.sol b/src/interfaces/IEulerEarn.sol
+index 27334f2..ed18e7e 100644
+--- a/src/interfaces/IEulerEarn.sol
++++ b/src/interfaces/IEulerEarn.sol
+@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
+ 
+ import {IEulerEarnFactory} from "./IEulerEarnFactory.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+-import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
++import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
+ 
+ import {MarketConfig, PendingUint136, PendingAddress} from "../libraries/PendingLib.sol";
+ 
+diff --git a/src/interfaces/IPublicAllocator.sol b/src/interfaces/IPublicAllocator.sol
+index b222ce3..4a9067b 100644
+--- a/src/interfaces/IPublicAllocator.sol
++++ b/src/interfaces/IPublicAllocator.sol
+@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
+ 
+ import {MarketAllocation} from "./IEulerEarn.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @dev Max settable flow cap, such that caps can always be stored on 128 bits.
+ /// @dev The actual max possible flow cap is type(uint128).max-1.
+diff --git a/src/libraries/ErrorsLib.sol b/src/libraries/ErrorsLib.sol
+index 300bb22..da0feca 100644
+--- a/src/libraries/ErrorsLib.sol
++++ b/src/libraries/ErrorsLib.sol
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ pragma solidity ^0.8.0;
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @title ErrorsLib
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/libraries/EventsLib.sol b/src/libraries/EventsLib.sol
+index f9dc967..862b344 100644
+--- a/src/libraries/EventsLib.sol
++++ b/src/libraries/EventsLib.sol
+@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
+ 
+ import {FlowCapsConfig} from "../interfaces/IPublicAllocator.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ import {PendingAddress} from "./PendingLib.sol";
+```
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+     /// @param account User account to query
+```
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/mainnet.md
+++ b/verify/mainnet.md
@@ -1,0 +1,281 @@
+# Mainnet Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x3EC2d5af...`](https://etherscan.io/address/0x3EC2d5af936bBB57DD19C292BAfb89da0E377F42) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0x0D52d06c...`](https://etherscan.io/address/0x0D52d06ceB8Dcdeeb40Cfd9f17489B350dD7F8a3) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 17/17 |
+| ✓ eulerEarnFactory | [`0x59709B02...`](https://etherscan.io/address/0x59709B029B140C853FE28d277f83C3a65e308aF4) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x8fdCb80a...`](https://etherscan.io/address/0x8fdCb80a2894F0dC052c8d52D22544DC90274800) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0xb013be1D...`](https://etherscan.io/address/0xb013be1D0D380C13B58e889f412895970A2Cf228) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0xc35a0FDA...`](https://etherscan.io/address/0xc35a0FDA69e9D71e68C0d9CBb541Adfd21D6B117) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0x208fF5Eb...`](https://etherscan.io/address/0x208fF5Eb543814789321DaA1B5Eb551881D16b06) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0xD0521333...`](https://etherscan.io/address/0xD05213331221fAB8a3C387F2affBb605Bb04DF5F) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x8B0E044E...`](https://etherscan.io/address/0x8B0E044E364F2cE913799d53b300e15A6974DC97) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0xD3a349EE...`](https://etherscan.io/address/0xD3a349EE0A21eA0A7E9513ac236ae614b5FD513E) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0x5171Aed0...`](https://etherscan.io/address/0x5171Aed04Fa9551DB484F07c853F252Bc6F53b63) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0x5FcCB843...`](https://etherscan.io/address/0x5FcCB84363F020c0cADE052C9c654aABF932814A) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0x4d7e09f7...`](https://etherscan.io/address/0x4d7e09f73843Bd4735AaF7A74b6d877bac75a531) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 12/12 |
+| ✓ eVaultFactory | [`0x29a56a1b...`](https://etherscan.io/address/0x29a56a1b8214D9Cf7c5561811750D5cBDb45CC8e) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`9e3c760e`](https://github.com/euler-xyz/euler-vault-kit/tree/9e3c760e051f5d769f7c6edb9be30198a55117d4) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+| ✓ eVaultImplementation | [`0x8Ff1C814...`](https://etherscan.io/address/0x8Ff1C814719096b61aBf00Bb46EAd0c9A529Dd7D) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`9e3c760e`](https://github.com/euler-xyz/euler-vault-kit/tree/9e3c760e051f5d769f7c6edb9be30198a55117d4) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 52/52 |
+| ✓ evc | [`0x0C9a3dd6...`](https://etherscan.io/address/0x0C9a3dd6b8F28529d72d7f9cE918D493519EE383) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`084b3228`](https://github.com/euler-xyz/ethereum-vault-connector/tree/084b32284ba643921f8d21bff3ddaf0c4e08d754) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 9/9 |
+| ✓ feeFlowController | [`0xFcd3Db06...`](https://etherscan.io/address/0xFcd3Db06EA814eB21C84304fC7F90798C00D1e32) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0xa8F8E82C...`](https://etherscan.io/address/0xa8F8E82C9Da15A991D7BF2486aE26e22743aC8d0) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x025C8831...`](https://etherscan.io/address/0x025C8831c6E45420DF8E71F7B6b99F733D120Faf) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0xcAe0A39B...`](https://etherscan.io/address/0xcAe0A39B45Ee9C3213f64392FA6DF30CE034C9F9) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 5/5 |
+| ✓ kinkyIRMFactory | [`0x010102da...`](https://etherscan.io/address/0x010102daAB6133d4f8cEB4C8842a70B9899Fc102) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0x70B3f6F6...`](https://etherscan.io/address/0x70B3f6F61b7Bf237DF04589DdAA842121072326A) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`dda7da3c`](https://github.com/euler-xyz/euler-price-oracle/tree/dda7da3c641e3bf98dd9c97c19a1c8b8a6c32e21) | [`5e066711`](https://github.com/euler-xyz/evk-periphery/tree/5e066711) | 13/13 |
+| ✓ protocolConfig | [`0x4cD6BF1D...`](https://etherscan.io/address/0x4cD6BF1D183264c02Be7748Cb5cd3A47d013351b) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`9e3c760e`](https://github.com/euler-xyz/euler-vault-kit/tree/9e3c760e051f5d769f7c6edb9be30198a55117d4) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 2/2 |
+| ✓ rEUL | [`0xf3e62139...`](https://etherscan.io/address/0xf3e621395fc714B90dA337AA9108771597b4E696) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`f61809fd`](https://github.com/euler-xyz/evk-periphery/tree/f61809fd) | [`f61809fd`](https://github.com/euler-xyz/evk-periphery/tree/f61809fd) | 21/21 |
+| ✓ sequenceRegistry | [`0xEADDD216...`](https://etherscan.io/address/0xEADDD21618ad5Deb412D3fD23580FD461c106B54) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`9e3c760e`](https://github.com/euler-xyz/euler-vault-kit/tree/9e3c760e051f5d769f7c6edb9be30198a55117d4) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 2/2 |
+| ✓ swapVerifier | [`0xae26485A...`](https://etherscan.io/address/0xae26485ACDDeFd486Fe9ad7C2b34169d360737c7) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `084b3228`
+
+**Contracts:** evc
+
+- **Deployed from:** [`084b3228`](https://github.com/euler-xyz/ethereum-vault-connector/tree/084b3228)
+- **Compare to master:** [`084b3228...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/084b3228...master)
+- **evk-periphery:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+
+```diff
+diff --git a/src/EthereumVaultConnector.sol b/src/EthereumVaultConnector.sol
+index 95009da..e6bc820 100644
+--- a/src/EthereumVaultConnector.sol
++++ b/src/EthereumVaultConnector.sol
+@@ -27,6 +27,8 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
+     string public constant name = "Ethereum Vault Connector";
+ 
+     uint160 internal constant ACCOUNT_ID_OFFSET = 8;
++    address internal constant EIP_7587_PRECOMPILES = 0x0000000000000000000000000000000000000100;
++    address internal constant COMMON_PREDEPLOYS = 0x4200000000000000000000000000000000000000;
+     bytes32 internal constant HASHED_NAME = keccak256(bytes(name));
+ 
+     bytes32 internal constant TYPE_HASH =
+@@ -1045,7 +1047,8 @@ contract EthereumVaultConnector is Events, Errors, TransientStorage, IEVC {
+     function isSignerValid(address signer) internal pure virtual returns (bool) {
+         // not valid if the signer address falls into any of the precompiles/predeploys
+         // addresses space (depends on the chain ID).
+-        return !haveCommonOwnerInternal(signer, address(0));
++        return !haveCommonOwnerInternal(signer, address(0)) && !haveCommonOwnerInternal(signer, EIP_7587_PRECOMPILES)
++            && !haveCommonOwnerInternal(signer, COMMON_PREDEPLOYS);
+     }
+ 
+     /// @notice Computes the permit hash for a given set of parameters.
+```
+
+### euler-price-oracle @ `dda7da3c`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`dda7da3c`](https://github.com/euler-xyz/euler-price-oracle/tree/dda7da3c)
+- **Compare to master:** [`dda7da3c...master`](https://github.com/euler-xyz/euler-price-oracle/compare/dda7da3c...master)
+- **evk-periphery:** [`5e066711`](https://github.com/euler-xyz/evk-periphery/tree/5e066711)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `9e3c760e`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`9e3c760e`](https://github.com/euler-xyz/euler-vault-kit/tree/9e3c760e)
+- **Compare to master:** [`9e3c760e...master`](https://github.com/euler-xyz/euler-vault-kit/compare/9e3c760e...master)
+- **evk-periphery:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+
+```diff
+diff --git a/src/EVault/modules/Governance.sol b/src/EVault/modules/Governance.sol
+index 5c728ed..08c5c96 100644
+--- a/src/EVault/modules/Governance.sol
++++ b/src/EVault/modules/Governance.sol
+@@ -290,7 +290,7 @@ abstract contract GovernanceModule is IGovernance, BalanceUtils, BorrowUtils, LT
+         ConfigAmount newBorrowLTV = borrowLTV.toConfigAmount();
+         ConfigAmount newLiquidationLTV = liquidationLTV.toConfigAmount();
+ 
+-        // The borrow LTV must be lower than or equal to the the converged liquidation LTV
++        // The borrow LTV must be lower than or equal to the converged liquidation LTV
+         if (newBorrowLTV > newLiquidationLTV) revert E_LTVBorrow();
+ 
+         LTVConfig memory currentLTV = vaultStorage.ltvLookup[collateral];
+@@ -304,12 +304,6 @@ abstract contract GovernanceModule is IGovernance, BalanceUtils, BorrowUtils, LT
+ 
+         if (!currentLTV.isRecognizedCollateral()) vaultStorage.ltvList.push(collateral);
+ 
+-        if (!newLiquidationLTV.isZero()) {
+-            // Ensure that this collateral can be priced by the configured oracle
+-            (, IPriceOracle _oracle, address _unitOfAccount) = ProxyUtils.metadata();
+-            _oracle.getQuote(1e18, collateral, _unitOfAccount);
+-        }
+-
+         emit GovSetLTV(
+             collateral,
+             newLTV.borrowLTV.toUint16(),
+```
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** kinkIRMFactory, swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/IRMFactory/EulerKinkIRMFactory.sol b/src/IRMFactory/EulerKinkIRMFactory.sol
+index 2b651a40..1d7b8fbf 100644
+--- a/src/IRMFactory/EulerKinkIRMFactory.sol
++++ b/src/IRMFactory/EulerKinkIRMFactory.sol
+@@ -4,12 +4,13 @@ pragma solidity ^0.8.0;
+ 
+ import {BaseFactory} from "../BaseFactory/BaseFactory.sol";
+ import {IRMLinearKink} from "evk/InterestRateModels/IRMLinearKink.sol";
++import {IEulerKinkIRMFactory} from "./interfaces/IEulerKinkIRMFactory.sol";
+ 
+ /// @title EulerKinkIRMFactory
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+ /// @notice A minimal factory for Kink IRMs.
+-contract EulerKinkIRMFactory is BaseFactory {
++contract EulerKinkIRMFactory is BaseFactory, IEulerKinkIRMFactory {
+     // corresponds to 1000% APY
+     uint256 internal constant MAX_ALLOWED_INTEREST_RATE = 75986279153383989049;
+ 
+@@ -22,7 +23,11 @@ contract EulerKinkIRMFactory is BaseFactory {
+     /// @param slope2 Slope of the function after the kink
+     /// @param kink Utilization at which the slope of the interest rate function changes. In type(uint32).max scale
+     /// @return The deployment address.
+-    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink) external returns (address) {
++    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink)
++        external
++        override
++        returns (address)
++    {
+         IRMLinearKink irm = new IRMLinearKink(baseRate, slope1, slope2, kink);
+ 
+         // verify if the IRM is functional
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+```
+
+_Showing first 100 of 101 lines. [View full diff on GitHub](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)_
+
+### evk-periphery @ `f61809fd`
+
+**Contracts:** rEUL
+
+- **Deployed from:** [`f61809fd`](https://github.com/euler-xyz/evk-periphery/tree/f61809fd)
+- **Compare to master:** [`f61809fd...master`](https://github.com/euler-xyz/evk-periphery/compare/f61809fd...master)
+
+_No diff available - see GitHub compare link above._
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/monad.md
+++ b/verify/monad.md
@@ -1,0 +1,195 @@
+# Monad Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 21 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **21** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x967803d8...`](https://monadvision.com/address/0x967803d884DF006A7150Bc3fCD416b813fbCbF4A) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0xa231DccE...`](https://monadvision.com/address/0xa231DccE58EA5A43E69EF351D89ea4212Ec0f30b) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0xF463d4Ac...`](https://monadvision.com/address/0xF463d4Acb650cc6C4E1D6cD4D0d1b0cb224094cF) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 37/37 |
+| ✓ eulerEarnPublicAllocator | [`0x65A66F24...`](https://monadvision.com/address/0x65A66F24a25E8CF651C9e31D296623298C80F742) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x34f8f028...`](https://monadvision.com/address/0x34f8f028c6a446a464c10a135f44fc6fb2cee1a9) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`5d270c7`](https://github.com/euler-xyz/euler-swap/tree/5d270c7) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0xbfd5c7bb...`](https://monadvision.com/address/0xbfd5c7bb1c208fec761284af7db6ff1f4314372c) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`5d270c7`](https://github.com/euler-xyz/euler-swap/tree/5d270c7) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0xd1f69cf9...`](https://monadvision.com/address/0xd1f69cf959c1a3aae7bee5ec677222d259585b27) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`98c05c5`](https://github.com/euler-xyz/euler-swap/tree/98c05c5) | - | 9/9 |
+| ✓ eulOFTAdapter | [`0x831257BF...`](https://monadvision.com/address/0x831257BFa5478111d2327e08c4068ec37Ac14B81) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0xba4Dd672...`](https://monadvision.com/address/0xba4Dd672062dE8FeeDb665DD4410658864483f1E) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0xef17750D...`](https://monadvision.com/address/0xef17750D3a162E28a302E266c474ff8989d60ECD) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x7a9324E8...`](https://monadvision.com/address/0x7a9324E8f270413fa2E458f5831226d99C7477CD) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0x9527062A...`](https://monadvision.com/address/0x9527062A472666410DC7193A966709105dF2f147) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x6F1228b0...`](https://monadvision.com/address/0x6F1228b0A111173Dd3A295D32b5157fA3410de96) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x21BFce0c...`](https://monadvision.com/address/0x21BFce0c4E9411cd6c7F6D28edC9244f89bFEe63) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x05Cccb5d...`](https://monadvision.com/address/0x05Cccb5d0f1e1D568804453B82453a719Dc53758) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ kinkyIRMFactory | [`0x3512f50B...`](https://monadvision.com/address/0x3512f50B3f0cA8725CcCBb6DDcc7307Ed2c17feb) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0xdDA3cBC1...`](https://monadvision.com/address/0xdDA3cBC18e90606A83FBae6F798991af06dFA902) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x94A2d1d1...`](https://monadvision.com/address/0x94A2d1d175F1d828935a374091e2009CF1cED858) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0xff074349...`](https://monadvision.com/address/0xff074349C8b89bB7362bD25c58742896D817A862) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0x39F81037...`](https://monadvision.com/address/0x39F81037f20AC6068CbCd30f748094c58bfE7d7b) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x65bF068c...`](https://monadvision.com/address/0x65bF068c88e0f006f76b871396B4DB1150dd9EAD) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+     /// @param account User account to query
+```
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/plasma.md
+++ b/verify/plasma.md
@@ -1,0 +1,79 @@
+# Plasma Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 7 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 19 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0xcC8169ED...`](https://plasmascan.to/address/0xcC8169EDFfe94726823fA71e0E7C64F130208c7e) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✗ balanceTracker | [`0x6e6e1e4F...`](https://plasmascan.to/address/0x6e6e1e4FB3Ee6C074f10d3f80E0d3541accf7c2b) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerEarnFactory | [`0xA3843A73...`](https://plasmascan.to/address/0xA3843A73e6a9F81309B931237Ca4759B3B02ff0E) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerEarnPublicAllocator | [`0x667aD135...`](https://plasmascan.to/address/0x667aD135188d95a32A4E743Aebe5a5b503cb9038) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV1Factory | [`0xD7aA0310...`](https://plasmascan.to/address/0xD7aA03104c2CCaC58acB00CbE90865FA64BbE77D) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV1Implementation | [`0x7F6ff62e...`](https://plasmascan.to/address/0x7F6ff62e7ECED715a2f4E5Ebe14eC9d32a44EFDc) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV1Periphery | [`0x1472ebB0...`](https://plasmascan.to/address/0x1472ebB000190275B5e28733e45a2614F1C3F41C) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV2Factory | [`0x29FAFDbf...`](https://plasmascan.to/address/0x29FAFDbf952e7b5c0A6Cd26957829334d54E872A) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV2Implementation | [`0xdAdBb7a0...`](https://plasmascan.to/address/0xdAdBb7a06638e3345A341002e956324A46d1c28c) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV2Periphery | [`0x741Fc7A9...`](https://plasmascan.to/address/0x741Fc7A904c9F810cbc4a21DE7D07B51B5Da853C) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV2ProtocolFeeConfig | [`0x8ec298B4...`](https://plasmascan.to/address/0x8ec298B473D17e04F819453C72747c3d4d6B7848) | - | Error: Not verified on explorer | - | - |
+| ✗ eulerSwapV2Registry | [`0x8D6A81Ec...`](https://plasmascan.to/address/0x8D6A81Ec8f5680849dCFBa47c710Dd9DA02aDaea) | - | Error: Not verified on explorer | - | - |
+| ✗ eulOFTAdapter | [`0x78F50C52...`](https://plasmascan.to/address/0x78F50C520E7fCE30410516B72A48bD4fc5d974b5) | - | Error: Not verified on explorer | - | - |
+| ✓ eVaultFactory | [`0x42388213...`](https://plasmascan.to/address/0x42388213C6F56D7E1477632b58Ae6Bba9adeEeA3) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x8346BeBa...`](https://plasmascan.to/address/0x8346BeBaA0789Eb92CFfCC07033b8bF9f3eFdcAB) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x7bdbd0A7...`](https://plasmascan.to/address/0x7bdbd0A7114aA42CA957F292145F6a931a345583) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✗ feeFlowController | [`0xBCc714F3...`](https://plasmascan.to/address/0xBCc714F3ce3F56aB4A85a10d593cF9C93ED6ED9e) | - | Error: Not verified on explorer | - | - |
+| ✗ fixedCyclicalBinaryIRMFactory | [`0xfdb6D727...`](https://plasmascan.to/address/0xfdb6D727785485f87caBEc64204cd7EBc930ef11) | - | Error: Not verified on explorer | - | - |
+| ✓ governorAccessControlEmergencyFactory | [`0xDb4bD546...`](https://plasmascan.to/address/0xDb4bD54647169b0d2b0414EfE943A92b6B8E9886) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0xACd19b80...`](https://plasmascan.to/address/0xACd19b80db7AF45BDdd5fD58dbc5dFe194137dB6) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✗ kinkyIRMFactory | [`0x6C72E825...`](https://plasmascan.to/address/0x6C72E825D37323F711bAc4aDaaE275ba5e3AEaF1) | - | Error: Not verified on explorer | - | - |
+| ✓ oracleRouterFactory | [`0x7e539159...`](https://plasmascan.to/address/0x7e539159a06CFe0A9f855d22dD82aD95eDf8C2F1) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✗ protocolConfig | [`0x593Ab8A0...`](https://plasmascan.to/address/0x593Ab8A0182f752c6f1af52CA2A0E8B9F868f64A) | - | Error: Not verified on explorer | - | - |
+| ✗ rEUL | [`0xe2011F2b...`](https://plasmascan.to/address/0xe2011F2bF6556863c3bacE991Efc8DaC26CD84c2) | - | Error: Not verified on explorer | - | - |
+| ✗ sequenceRegistry | [`0x3cf6e4c1...`](https://plasmascan.to/address/0x3cf6e4c11333b30f0D0CEAe6B78f53a660df357c) | - | Error: Not verified on explorer | - | - |
+| ✗ swapVerifier | [`0xB695C0aC...`](https://plasmascan.to/address/0xB695C0aC484F46dD8f279452209b8C53674974bD) | - | Error: Not verified on explorer | - | - |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/sonic.md
+++ b/verify/sonic.md
@@ -1,0 +1,355 @@
+# Sonic Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x1515a135...`](https://sonicscan.org/address/0x1515a13551fDF554203f2a86021e0370a08a8D94) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0xe6E4687C...`](https://sonicscan.org/address/0xe6E4687C35429942391AfE42CDdECba857531492) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0x3397ec7d...`](https://sonicscan.org/address/0x3397ec7d28cF645A017869Fe4B41c75f5B0b75a8) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x82b27b52...`](https://sonicscan.org/address/0x82b27b528DA0516E653e02e5f870853d22Cbc6Df) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x94041db6...`](https://sonicscan.org/address/0x94041db6deC15f79666B07846c13e6F7341b4a80) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x4D57F545...`](https://sonicscan.org/address/0x4D57F54582b333E4184A3cF40d1D61FE6D70c35D) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0xb2237DC8...`](https://sonicscan.org/address/0xb2237DC86B184e50Fc2F8b028B2b7AE192ef2566) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0x46D23b2d...`](https://sonicscan.org/address/0x46D23b2d948b159859A5BB9C96c3190F4b43Ebb6) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x1C266a98...`](https://sonicscan.org/address/0x1C266a986B6AfA7EbA68263c5323a0bF0fe4F2a4) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0x4e4e5246...`](https://sonicscan.org/address/0x4e4e524613d840D2D30B694F363b5b1931e82A75) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0x8653d1B5...`](https://sonicscan.org/address/0x8653d1B50AA6adaaD64Dc140588dBC8c11141581) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0x0601a383...`](https://sonicscan.org/address/0x0601a38324D3cde22EBD531c799Ad318a6B8CF93) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0x31aA7423...`](https://sonicscan.org/address/0x31aA74232A0b0E50e5bF95780b2116710a34c7E9) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0xF075cC86...`](https://sonicscan.org/address/0xF075cC8660B51D0b8a4474e3f47eDAC5fA034cFB) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x11f95aaa...`](https://sonicscan.org/address/0x11f95aaa59F1AD89576c61E3C9Cd24DF1FdCF46f) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x4860C903...`](https://sonicscan.org/address/0x4860C903f6Ad709c3eDA46D3D502943f184D4315) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0xD3Cf3Ec3...`](https://sonicscan.org/address/0xD3Cf3Ec3D7849F2C7Bb9Ff5a8662Ae36a177bEb8) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x5d403c8A...`](https://sonicscan.org/address/0x5d403c8Ad3300B0cB689eA243336F4d39d0e4Dae) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0xE83A3ba3...`](https://sonicscan.org/address/0xE83A3ba3D2D04b6bfeeA198e27d2f6cA7e125bA1) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x52E85679...`](https://sonicscan.org/address/0x52E856790779fD4fCa34bA52C67Cd191338572C0) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 5/5 |
+| ✓ kinkyIRMFactory | [`0xd10aa71E...`](https://sonicscan.org/address/0xd10aa71E7bAEC97C397829BEdb5a3504546fe149) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0xc5b9B95a...`](https://sonicscan.org/address/0xc5b9B95a769C24c18c344c2659db61a0AdFB736E) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0xc2f9FE90...`](https://sonicscan.org/address/0xc2f9FE90bd17e017898b6EfDaa73c34Fddde299e) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0x09E6cab4...`](https://sonicscan.org/address/0x09E6cab47B7199b9d3839A2C40654f246d518a80) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0x6F417AaE...`](https://sonicscan.org/address/0x6F417AaEc1D41dB692307269acDA019Ce5F10b0e) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x003ef404...`](https://sonicscan.org/address/0x003ef4048b45a5A79D4499aaBd52108B3Bc9209f) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-earn @ `773453b`
+
+**Contracts:** eulerEarnFactory
+
+- **Deployed from:** [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b)
+- **Compare to master:** [`773453b...master`](https://github.com/euler-xyz/euler-earn/compare/773453b...master)
+
+```diff
+diff --git a/src/EulerEarn.sol b/src/EulerEarn.sol
+index 4635a89..27c1873 100644
+--- a/src/EulerEarn.sol
++++ b/src/EulerEarn.sol
+@@ -17,12 +17,12 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ import {EventsLib} from "./libraries/EventsLib.sol";
+ import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
+ import {UtilsLib, WAD} from "./libraries/UtilsLib.sol";
+-import {SafeCast} from "../lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+-import {IERC20Metadata} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
++import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
++import {IERC20Metadata} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Metadata.sol";
+ 
+-import {Context} from "../lib/openzeppelin-contracts/contracts/utils/Context.sol";
+-import {ReentrancyGuard} from "../lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+-import {Ownable2Step, Ownable} from "../lib/openzeppelin-contracts/contracts/access/Ownable2Step.sol";
++import {Context} from "openzeppelin-contracts/utils/Context.sol";
++import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
++import {Ownable2Step, Ownable} from "openzeppelin-contracts/access/Ownable2Step.sol";
+ import {
+     IERC20,
+     IERC4626,
+@@ -30,8 +30,8 @@ import {
+     ERC4626,
+     Math,
+     SafeERC20
+-} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++} from "openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarn
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/EulerEarnFactory.sol b/src/EulerEarnFactory.sol
+index 758185e..e7fd335 100644
+--- a/src/EulerEarnFactory.sol
++++ b/src/EulerEarnFactory.sol
+@@ -10,8 +10,8 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ 
+ import {EulerEarn} from "./EulerEarn.sol";
+ 
+-import {Ownable, Context} from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++import {Ownable, Context} from "openzeppelin-contracts/access/Ownable.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarnFactory
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/interfaces/IEulerEarn.sol b/src/interfaces/IEulerEarn.sol
+index 27334f2..ed18e7e 100644
+--- a/src/interfaces/IEulerEarn.sol
++++ b/src/interfaces/IEulerEarn.sol
+@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
+ 
+ import {IEulerEarnFactory} from "./IEulerEarnFactory.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+-import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
++import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
+ 
+ import {MarketConfig, PendingUint136, PendingAddress} from "../libraries/PendingLib.sol";
+ 
+diff --git a/src/interfaces/IPublicAllocator.sol b/src/interfaces/IPublicAllocator.sol
+index b222ce3..4a9067b 100644
+--- a/src/interfaces/IPublicAllocator.sol
++++ b/src/interfaces/IPublicAllocator.sol
+@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
+ 
+ import {MarketAllocation} from "./IEulerEarn.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @dev Max settable flow cap, such that caps can always be stored on 128 bits.
+ /// @dev The actual max possible flow cap is type(uint128).max-1.
+diff --git a/src/libraries/ErrorsLib.sol b/src/libraries/ErrorsLib.sol
+index 300bb22..da0feca 100644
+--- a/src/libraries/ErrorsLib.sol
++++ b/src/libraries/ErrorsLib.sol
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ pragma solidity ^0.8.0;
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @title ErrorsLib
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/libraries/EventsLib.sol b/src/libraries/EventsLib.sol
+index f9dc967..862b344 100644
+--- a/src/libraries/EventsLib.sol
++++ b/src/libraries/EventsLib.sol
+@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
+ 
+ import {FlowCapsConfig} from "../interfaces/IPublicAllocator.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+```
+
+_Showing first 100 of 117 lines. [View full diff on GitHub](https://github.com/euler-xyz/euler-earn/compare/773453b...master)_
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** kinkIRMFactory, swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/IRMFactory/EulerKinkIRMFactory.sol b/src/IRMFactory/EulerKinkIRMFactory.sol
+index 2b651a40..1d7b8fbf 100644
+--- a/src/IRMFactory/EulerKinkIRMFactory.sol
++++ b/src/IRMFactory/EulerKinkIRMFactory.sol
+@@ -4,12 +4,13 @@ pragma solidity ^0.8.0;
+ 
+ import {BaseFactory} from "../BaseFactory/BaseFactory.sol";
+ import {IRMLinearKink} from "evk/InterestRateModels/IRMLinearKink.sol";
++import {IEulerKinkIRMFactory} from "./interfaces/IEulerKinkIRMFactory.sol";
+ 
+ /// @title EulerKinkIRMFactory
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+ /// @notice A minimal factory for Kink IRMs.
+-contract EulerKinkIRMFactory is BaseFactory {
++contract EulerKinkIRMFactory is BaseFactory, IEulerKinkIRMFactory {
+     // corresponds to 1000% APY
+     uint256 internal constant MAX_ALLOWED_INTEREST_RATE = 75986279153383989049;
+ 
+@@ -22,7 +23,11 @@ contract EulerKinkIRMFactory is BaseFactory {
+     /// @param slope2 Slope of the function after the kink
+     /// @param kink Utilization at which the slope of the interest rate function changes. In type(uint32).max scale
+     /// @return The deployment address.
+-    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink) external returns (address) {
++    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink)
++        external
++        override
++        returns (address)
++    {
+         IRMLinearKink irm = new IRMLinearKink(baseRate, slope1, slope2, kink);
+ 
+         // verify if the IRM is functional
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+```
+
+_Showing first 100 of 101 lines. [View full diff on GitHub](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)_
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/swell.md
+++ b/verify/swell.md
@@ -1,0 +1,355 @@
+# Swell Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x73ab4387...`](https://explorer.swellnetwork.io/address/0x73ab43878997BcDc5d726b7aE76F149ebe9d3AA9) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0x9fb7215e...`](https://explorer.swellnetwork.io/address/0x9fb7215ef6297498D6807caf9f3aC8BA3154db29) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`8695c72c`](https://github.com/euler-xyz/evk-periphery/tree/8695c72c) | 17/17 |
+| ✓ eulerEarnFactory | [`0x3073e1B4...`](https://explorer.swellnetwork.io/address/0x3073e1B42f8Cc933f2d678DdA10acDE51F4E49a3) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x0a13C9fc...`](https://explorer.swellnetwork.io/address/0x0a13C9fc4613Cae202138F4E1C2b9125A20562E8) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x976dd856...`](https://explorer.swellnetwork.io/address/0x976dd85654B3b2f9fb66280ACE30Cab7C81a2130) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0x3620dAb0...`](https://explorer.swellnetwork.io/address/0x3620dAb0DB5595479a4D5408595D48FbE48CeA2A) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0x34932C04...`](https://explorer.swellnetwork.io/address/0x34932C04c3d27c2BD7aCd0B5d203bfd65a17f481) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0x980cd01d...`](https://explorer.swellnetwork.io/address/0x980cd01dB708C2B008cF8076aa856fcAeF60698c) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0xCB728171...`](https://explorer.swellnetwork.io/address/0xCB72817170a9d0f136fcB764f55BEEC638C25acb) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0x74F7726e...`](https://explorer.swellnetwork.io/address/0x74F7726eF6D8107403a6c581B985D27ED0561f9D) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0x6FB6C91e...`](https://explorer.swellnetwork.io/address/0x6FB6C91e369fD151eB343de3BE76F3617FbFfDf2) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0x33274281...`](https://explorer.swellnetwork.io/address/0x3327428147E0cE4Cb185A82F756CaE0D429dbd2c) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0xD0148dDB...`](https://explorer.swellnetwork.io/address/0xD0148dDB69f4d8182Ef863d6f81ED6519D8c83a2) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x238bF86b...`](https://explorer.swellnetwork.io/address/0x238bF86bb451ec3CA69BB855f91BDA001aB118b9) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x70f12862...`](https://explorer.swellnetwork.io/address/0x70f1286239228B28A047c727C2df390045299486) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x08739CBe...`](https://explorer.swellnetwork.io/address/0x08739CBede6E28E387685ba20e6409bD16969Cde) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0xA93Ff8C4...`](https://explorer.swellnetwork.io/address/0xA93Ff8C4CC2Ba56Ee182B70bb07F2C75DA249879) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0xb30F5540...`](https://explorer.swellnetwork.io/address/0xb30F5540dd93Fd5569c9638B7bF11A4a926E8D17) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x88B049E6...`](https://explorer.swellnetwork.io/address/0x88B049E6e1A3e11306aC437bbedD0077a2859A36) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0xBECb652F...`](https://explorer.swellnetwork.io/address/0xBECb652Fded7024765575165A98Bfe30b7374058) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 5/5 |
+| ✓ kinkyIRMFactory | [`0xb6d62828...`](https://explorer.swellnetwork.io/address/0xb6d62828ba6063B9d4fD504A70d6a9B2f24b1918) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0x0135fC26...`](https://explorer.swellnetwork.io/address/0x0135fC2605ff2C89E550C2d4C7d75068A4782B43) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x6682Af28...`](https://explorer.swellnetwork.io/address/0x6682Af2820633067A1de5bE99b2DCb2d38F1e241) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0x021694af...`](https://explorer.swellnetwork.io/address/0x021694af083d67950Ac994E63e0a70C30D913836) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0xC4589C61...`](https://explorer.swellnetwork.io/address/0xC4589C6199516F96B422D91020563Fe65b28918e) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x392C1570...`](https://explorer.swellnetwork.io/address/0x392C1570b3Bf29B113944b759cAa9a9282DA12Fe) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-earn @ `773453b`
+
+**Contracts:** eulerEarnFactory
+
+- **Deployed from:** [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b)
+- **Compare to master:** [`773453b...master`](https://github.com/euler-xyz/euler-earn/compare/773453b...master)
+
+```diff
+diff --git a/src/EulerEarn.sol b/src/EulerEarn.sol
+index 4635a89..27c1873 100644
+--- a/src/EulerEarn.sol
++++ b/src/EulerEarn.sol
+@@ -17,12 +17,12 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ import {EventsLib} from "./libraries/EventsLib.sol";
+ import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
+ import {UtilsLib, WAD} from "./libraries/UtilsLib.sol";
+-import {SafeCast} from "../lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+-import {IERC20Metadata} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
++import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
++import {IERC20Metadata} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Metadata.sol";
+ 
+-import {Context} from "../lib/openzeppelin-contracts/contracts/utils/Context.sol";
+-import {ReentrancyGuard} from "../lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+-import {Ownable2Step, Ownable} from "../lib/openzeppelin-contracts/contracts/access/Ownable2Step.sol";
++import {Context} from "openzeppelin-contracts/utils/Context.sol";
++import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
++import {Ownable2Step, Ownable} from "openzeppelin-contracts/access/Ownable2Step.sol";
+ import {
+     IERC20,
+     IERC4626,
+@@ -30,8 +30,8 @@ import {
+     ERC4626,
+     Math,
+     SafeERC20
+-} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++} from "openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarn
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/EulerEarnFactory.sol b/src/EulerEarnFactory.sol
+index 758185e..e7fd335 100644
+--- a/src/EulerEarnFactory.sol
++++ b/src/EulerEarnFactory.sol
+@@ -10,8 +10,8 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ 
+ import {EulerEarn} from "./EulerEarn.sol";
+ 
+-import {Ownable, Context} from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++import {Ownable, Context} from "openzeppelin-contracts/access/Ownable.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarnFactory
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/interfaces/IEulerEarn.sol b/src/interfaces/IEulerEarn.sol
+index 27334f2..ed18e7e 100644
+--- a/src/interfaces/IEulerEarn.sol
++++ b/src/interfaces/IEulerEarn.sol
+@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
+ 
+ import {IEulerEarnFactory} from "./IEulerEarnFactory.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+-import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
++import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
+ 
+ import {MarketConfig, PendingUint136, PendingAddress} from "../libraries/PendingLib.sol";
+ 
+diff --git a/src/interfaces/IPublicAllocator.sol b/src/interfaces/IPublicAllocator.sol
+index b222ce3..4a9067b 100644
+--- a/src/interfaces/IPublicAllocator.sol
++++ b/src/interfaces/IPublicAllocator.sol
+@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
+ 
+ import {MarketAllocation} from "./IEulerEarn.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @dev Max settable flow cap, such that caps can always be stored on 128 bits.
+ /// @dev The actual max possible flow cap is type(uint128).max-1.
+diff --git a/src/libraries/ErrorsLib.sol b/src/libraries/ErrorsLib.sol
+index 300bb22..da0feca 100644
+--- a/src/libraries/ErrorsLib.sol
++++ b/src/libraries/ErrorsLib.sol
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ pragma solidity ^0.8.0;
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @title ErrorsLib
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/libraries/EventsLib.sol b/src/libraries/EventsLib.sol
+index f9dc967..862b344 100644
+--- a/src/libraries/EventsLib.sol
++++ b/src/libraries/EventsLib.sol
+@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
+ 
+ import {FlowCapsConfig} from "../interfaces/IPublicAllocator.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+```
+
+_Showing first 100 of 117 lines. [View full diff on GitHub](https://github.com/euler-xyz/euler-earn/compare/773453b...master)_
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** kinkIRMFactory, swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/IRMFactory/EulerKinkIRMFactory.sol b/src/IRMFactory/EulerKinkIRMFactory.sol
+index 2b651a40..1d7b8fbf 100644
+--- a/src/IRMFactory/EulerKinkIRMFactory.sol
++++ b/src/IRMFactory/EulerKinkIRMFactory.sol
+@@ -4,12 +4,13 @@ pragma solidity ^0.8.0;
+ 
+ import {BaseFactory} from "../BaseFactory/BaseFactory.sol";
+ import {IRMLinearKink} from "evk/InterestRateModels/IRMLinearKink.sol";
++import {IEulerKinkIRMFactory} from "./interfaces/IEulerKinkIRMFactory.sol";
+ 
+ /// @title EulerKinkIRMFactory
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+ /// @notice A minimal factory for Kink IRMs.
+-contract EulerKinkIRMFactory is BaseFactory {
++contract EulerKinkIRMFactory is BaseFactory, IEulerKinkIRMFactory {
+     // corresponds to 1000% APY
+     uint256 internal constant MAX_ALLOWED_INTEREST_RATE = 75986279153383989049;
+ 
+@@ -22,7 +23,11 @@ contract EulerKinkIRMFactory is BaseFactory {
+     /// @param slope2 Slope of the function after the kink
+     /// @param kink Utilization at which the slope of the interest rate function changes. In type(uint32).max scale
+     /// @return The deployment address.
+-    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink) external returns (address) {
++    function deploy(uint256 baseRate, uint256 slope1, uint256 slope2, uint32 kink)
++        external
++        override
++        returns (address)
++    {
+         IRMLinearKink irm = new IRMLinearKink(baseRate, slope1, slope2, kink);
+ 
+         // verify if the IRM is functional
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+```
+
+_Showing first 100 of 101 lines. [View full diff on GitHub](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)_
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`8695c72c`](https://github.com/euler-xyz/evk-periphery/tree/8695c72c)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/tac.md
+++ b/verify/tac.md
@@ -1,0 +1,210 @@
+# Tac Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0x13703f8E...`](https://explorer.tac.build/address/0x13703f8E7bAa5c99Fc9CD9EE1976dC7B562e5183) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0x45ff89cD...`](https://explorer.tac.build/address/0x45ff89cD0e976392703048F4A4314A2010ee64b8) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 17/17 |
+| ✓ eulerEarnFactory | [`0x7670572a...`](https://explorer.tac.build/address/0x7670572aa76E6140400A948e7AAFAB0210a86d9f) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x4873ff8a...`](https://explorer.tac.build/address/0x4873ff8a70aA92443321Edb34a48f6aBfA7feB96) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x6A721609...`](https://explorer.tac.build/address/0x6A72160963a562f21387B166aF31a92D154106fb) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0xDFfaC13f...`](https://explorer.tac.build/address/0xDFfaC13fC142Fc1d8E55226dB9c98f4b66371a3c) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0xAF596563...`](https://explorer.tac.build/address/0xAF596563109C753b9c5e73DD596DD4bB247964cA) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0xb0b53c1A...`](https://explorer.tac.build/address/0xb0b53c1A8046D92027B69D9f6D9C7cFC0f363933) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x32Da74f7...`](https://explorer.tac.build/address/0x32Da74f7bC1988c1c39adB561b6e9D2a6F33D404) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0xD356C065...`](https://explorer.tac.build/address/0xD356C065777871B37Cb0D3C7761b8820c832BC57) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0xb7F14f64...`](https://explorer.tac.build/address/0xb7F14f649770fB7784A02A94946D14E80f79d660) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0xd3ee9112...`](https://explorer.tac.build/address/0xd3ee91128294Ca8231260891BEC6Da7d258De7B6) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0xe7c41548...`](https://explorer.tac.build/address/0xe7c415484348d14c0e6B8C18E110D72EcA17d306) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0x2b21621b...`](https://explorer.tac.build/address/0x2b21621b8Ef1406699a99071ce04ec14cCd50677) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x1974899F...`](https://explorer.tac.build/address/0x1974899F5d6B5a1f8E63b2e8Ad60e14BAC3E7980) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x01F594c6...`](https://explorer.tac.build/address/0x01F594c66A5561b90Bc782dD0297f294cD668b64) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0x9128754f...`](https://explorer.tac.build/address/0x9128754f3951a819528d110f3a92a2586D352463) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x2d4Efa10...`](https://explorer.tac.build/address/0x2d4Efa10E128FbA4209D04866D7A732E8DceE453) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ governorAccessControlEmergencyFactory | [`0x38d17d93...`](https://explorer.tac.build/address/0x38d17d931FC1b6D79142Ba00e8F8ea89952cD2AB) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x80727c2F...`](https://explorer.tac.build/address/0x80727c2F6A2cc64D19Ca5B7614b4bf826Dd95DcC) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ kinkyIRMFactory | [`0x858F7F1F...`](https://explorer.tac.build/address/0x858F7F1FBB823eB97a300a31833DfAE7CA7Ec24A) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ oracleRouterFactory | [`0x0512F7cb...`](https://explorer.tac.build/address/0x0512F7cbc4Fd9d8BC47FfFa3aA0372bA2375158E) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0x4C3D26D7...`](https://explorer.tac.build/address/0x4C3D26D7Eb6D5AA62CFD99624ad4Ff3351E4B129) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0xCf623E50...`](https://explorer.tac.build/address/0xCf623E50430CCb55214985F9C986a5Fa50aD7686) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0xF7a9F90b...`](https://explorer.tac.build/address/0xF7a9F90b5ACb4EE4Cd536940142A04522D28e0Aa) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x5a8610DB...`](https://explorer.tac.build/address/0x5a8610DB17CfF800C8abEb6Da31B9bB1fF51843f) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+     /// @param account User account to query
+```
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+

--- a/verify/unichain.md
+++ b/verify/unichain.md
@@ -1,0 +1,322 @@
+# Unichain Contract Verification Report
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| ✓ Verified (exact match) | 26 |
+| ✗ No exact commit found | 0 |
+| ~ Standalone with diff | 0 |
+| - Error | 0 |
+| **Total** | **26** |
+
+## Verified Contracts
+
+| Contract | Address | Source Repo | Source Commit | evk-periphery | Files |
+|----------|---------|-------------|---------------|---------------|-------|
+| ✓ adaptiveCurveIRMFactory | [`0xbAbbE203...`](https://unichain.blockscout.com/address/0xbAbbE203727f8327106e6087f075F2B2F2B738d1) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ balanceTracker | [`0xFbD12fbC...`](https://unichain.blockscout.com/address/0xFbD12fbC91311A8f17598b935e35205EAF16Aa75) | [reward-streams](https://github.com/euler-xyz/reward-streams) | [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7fa31c275d688063c4abd07165b50b89f) | [`deploy-swell`](https://github.com/euler-xyz/evk-periphery/tree/deploy-swell) | 17/17 |
+| ✓ eulerEarnFactory | [`0xD785adD5...`](https://unichain.blockscout.com/address/0xD785adD5F081F56616898E45b90dE307e3DC7d3E) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b) | - | 35/35 |
+| ✓ eulerEarnPublicAllocator | [`0x68a823a4...`](https://unichain.blockscout.com/address/0x68a823a484a9D5A8daBB55c4d4d8006a45E557A9) | [euler-earn](https://github.com/euler-xyz/euler-earn) | [`master`](https://github.com/euler-xyz/euler-earn/tree/master) | - | 14/14 |
+| ✓ eulerSwapV1Factory | [`0x45b146BC...`](https://unichain.blockscout.com/address/0x45b146BC07c9985589B52df651310e75C6BE066A) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 55/55 |
+| ✓ eulerSwapV1Implementation | [`0xd91B0bfA...`](https://unichain.blockscout.com/address/0xd91B0bfACA4691E6Aca7E0E83D9B7F8917989a03) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 46/46 |
+| ✓ eulerSwapV1Periphery | [`0xdAAF468d...`](https://unichain.blockscout.com/address/0xdAAF468d84DD8945521Ea40297ce6c5EEfc7003a) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`eulerswap-1.0`](https://github.com/euler-xyz/euler-swap/tree/eulerswap-1.0) | - | 9/9 |
+| ✓ eulerSwapV2Factory | [`0xf211d70E...`](https://unichain.blockscout.com/address/0xf211d70Ed785f0e981E9F3188804Af43734502F1) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 57/57 |
+| ✓ eulerSwapV2Implementation | [`0x144f1715...`](https://unichain.blockscout.com/address/0x144f1715c673dA83917B09A5B4C23E2d72c8D411) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 54/54 |
+| ✓ eulerSwapV2Periphery | [`0xAD335516...`](https://unichain.blockscout.com/address/0xAD335516c6E17815d9DD543fBCDFE325F8563E13) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 11/11 |
+| ✓ eulerSwapV2ProtocolFeeConfig | [`0xeA96Ed68...`](https://unichain.blockscout.com/address/0xeA96Ed6896aB1F00e4Fc28C75D8e6655e56Cef85) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 5/5 |
+| ✓ eulerSwapV2Registry | [`0x9D9ce154...`](https://unichain.blockscout.com/address/0x9D9ce1540b986eF77c02F8D40603193852D2E723) | [euler-swap](https://github.com/euler-xyz/euler-swap) | [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc988468fd56f690e6bc0e338a5be02d034) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 35/35 |
+| ✓ eulOFTAdapter | [`0x41a11d85...`](https://unichain.blockscout.com/address/0x41a11d85577Bb21743E11Eca62e2b241DC1eD5C0) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0) | 63/63 |
+| ✓ eVaultFactory | [`0xbAd8b5BD...`](https://unichain.blockscout.com/address/0xbAd8b5BDFB2bcbcd78Cc9f1573D3Aad6E865e752) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 3/3 |
+| ✓ eVaultImplementation | [`0x71d72507...`](https://unichain.blockscout.com/address/0x71d7250732591C41D1BdeB1EA0Ee730E138E0c8b) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 52/52 |
+| ✓ evc | [`0x2A117696...`](https://unichain.blockscout.com/address/0x2A1176964F5D7caE5406B627Bf6166664FE83c60) | [ethereum-vault-connector](https://github.com/euler-xyz/ethereum-vault-connector) | [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29ef7e4964736e47675e0588630d6afbfd7) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 9/9 |
+| ✓ feeFlowController | [`0x87BeecC6...`](https://unichain.blockscout.com/address/0x87BeecC6B609723B2Ef071c20AA756846969240C) | [fee-flow](https://github.com/euler-xyz/fee-flow) | [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94e9cd68f65e11f07da9a69f726177cb9c) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 6/6 |
+| ✓ fixedCyclicalBinaryIRMFactory | [`0x6725657e...`](https://unichain.blockscout.com/address/0x6725657eCF5f7Cc46D1E848376b4dB92D71D0d96) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 7/7 |
+| ✓ governorAccessControlEmergencyFactory | [`0x4F74dEd1...`](https://unichain.blockscout.com/address/0x4F74dEd1980096C44B5fEE2A697B4B05AC75d987) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 48/48 |
+| ✓ kinkIRMFactory | [`0x34f3Ecd3...`](https://unichain.blockscout.com/address/0x34f3Ecd35E05b0554B6F4ee5Ba3A373ADd6a2538) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 6/6 |
+| ✓ kinkyIRMFactory | [`0x80594D09...`](https://unichain.blockscout.com/address/0x80594D095B69C7E8AC4B9fc00da59e0504C3b9f5) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 7/7 |
+| ✓ oracleRouterFactory | [`0xE551288F...`](https://unichain.blockscout.com/address/0xE551288F0D82C10bBF517DBA66E15C60BF87FE8f) | [euler-price-oracle](https://github.com/euler-xyz/euler-price-oracle) | [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b587c7fa90a7e722d52698003451feb62) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 13/13 |
+| ✓ protocolConfig | [`0xdCD02E4e...`](https://unichain.blockscout.com/address/0xdCD02E4eA8cd273498D315AD8c047305f8480656) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ rEUL | [`0x1b0e3Da5...`](https://unichain.blockscout.com/address/0x1b0e3Da51b2517E09aE74CD31b708e46B9158E8b) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | [`master`](https://github.com/euler-xyz/evk-periphery) | 21/21 |
+| ✓ sequenceRegistry | [`0x08799a00...`](https://unichain.blockscout.com/address/0x08799a00BC4a74890d65f77828cd2BFbBFcD96dB) | [euler-vault-kit](https://github.com/euler-xyz/euler-vault-kit) | [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf2447047d32aa9f4e5bab4be16ab3ea67ec2) | [`master`](https://github.com/euler-xyz/evk-periphery/tree/master) | 2/2 |
+| ✓ swapVerifier | [`0x7eaf8C22...`](https://unichain.blockscout.com/address/0x7eaf8C22480129E5D7426e3A33880D7bE19B50a7) | [evk-periphery](https://github.com/euler-xyz/evk-periphery) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370) | 3/3 |
+
+
+## Changes Since Deployment
+
+This section shows what has changed in the source code between the deployment commit and current `master`.
+These diffs help identify any changes made to the codebase after deployment.
+
+### ethereum-vault-connector @ `a7d3c29e`
+
+**Contracts:** evc
+
+- **Deployed from:** [`a7d3c29e`](https://github.com/euler-xyz/ethereum-vault-connector/tree/a7d3c29e)
+- **Compare to master:** [`a7d3c29e...master`](https://github.com/euler-xyz/ethereum-vault-connector/compare/a7d3c29e...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-earn @ `773453b`
+
+**Contracts:** eulerEarnFactory
+
+- **Deployed from:** [`773453b`](https://github.com/euler-xyz/euler-earn/tree/773453b)
+- **Compare to master:** [`773453b...master`](https://github.com/euler-xyz/euler-earn/compare/773453b...master)
+
+```diff
+diff --git a/src/EulerEarn.sol b/src/EulerEarn.sol
+index 4635a89..27c1873 100644
+--- a/src/EulerEarn.sol
++++ b/src/EulerEarn.sol
+@@ -17,12 +17,12 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ import {EventsLib} from "./libraries/EventsLib.sol";
+ import {SafeERC20Permit2Lib} from "./libraries/SafeERC20Permit2Lib.sol";
+ import {UtilsLib, WAD} from "./libraries/UtilsLib.sol";
+-import {SafeCast} from "../lib/openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+-import {IERC20Metadata} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol";
++import {SafeCast} from "openzeppelin-contracts/utils/math/SafeCast.sol";
++import {IERC20Metadata} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Metadata.sol";
+ 
+-import {Context} from "../lib/openzeppelin-contracts/contracts/utils/Context.sol";
+-import {ReentrancyGuard} from "../lib/openzeppelin-contracts/contracts/utils/ReentrancyGuard.sol";
+-import {Ownable2Step, Ownable} from "../lib/openzeppelin-contracts/contracts/access/Ownable2Step.sol";
++import {Context} from "openzeppelin-contracts/utils/Context.sol";
++import {ReentrancyGuard} from "openzeppelin-contracts/utils/ReentrancyGuard.sol";
++import {Ownable2Step, Ownable} from "openzeppelin-contracts/access/Ownable2Step.sol";
+ import {
+     IERC20,
+     IERC4626,
+@@ -30,8 +30,8 @@ import {
+     ERC4626,
+     Math,
+     SafeERC20
+-} from "../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++} from "openzeppelin-contracts/token/ERC20/extensions/ERC4626.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarn
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/EulerEarnFactory.sol b/src/EulerEarnFactory.sol
+index 758185e..e7fd335 100644
+--- a/src/EulerEarnFactory.sol
++++ b/src/EulerEarnFactory.sol
+@@ -10,8 +10,8 @@ import {ErrorsLib} from "./libraries/ErrorsLib.sol";
+ 
+ import {EulerEarn} from "./EulerEarn.sol";
+ 
+-import {Ownable, Context} from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
+-import {EVCUtil} from "../lib/ethereum-vault-connector/src/utils/EVCUtil.sol";
++import {Ownable, Context} from "openzeppelin-contracts/access/Ownable.sol";
++import {EVCUtil} from "ethereum-vault-connector/utils/EVCUtil.sol";
+ 
+ /// @title EulerEarnFactory
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/interfaces/IEulerEarn.sol b/src/interfaces/IEulerEarn.sol
+index 27334f2..ed18e7e 100644
+--- a/src/interfaces/IEulerEarn.sol
++++ b/src/interfaces/IEulerEarn.sol
+@@ -3,8 +3,8 @@ pragma solidity >=0.5.0;
+ 
+ import {IEulerEarnFactory} from "./IEulerEarnFactory.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
+-import {IERC20Permit} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Permit.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
++import {IERC20Permit} from "openzeppelin-contracts/token/ERC20/extensions/IERC20Permit.sol";
+ 
+ import {MarketConfig, PendingUint136, PendingAddress} from "../libraries/PendingLib.sol";
+ 
+diff --git a/src/interfaces/IPublicAllocator.sol b/src/interfaces/IPublicAllocator.sol
+index b222ce3..4a9067b 100644
+--- a/src/interfaces/IPublicAllocator.sol
++++ b/src/interfaces/IPublicAllocator.sol
+@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
+ 
+ import {MarketAllocation} from "./IEulerEarn.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @dev Max settable flow cap, such that caps can always be stored on 128 bits.
+ /// @dev The actual max possible flow cap is type(uint128).max-1.
+diff --git a/src/libraries/ErrorsLib.sol b/src/libraries/ErrorsLib.sol
+index 300bb22..da0feca 100644
+--- a/src/libraries/ErrorsLib.sol
++++ b/src/libraries/ErrorsLib.sol
+@@ -1,7 +1,7 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ pragma solidity ^0.8.0;
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+ /// @title ErrorsLib
+ /// @author Forked with gratitude from Morpho Labs. Inspired by Silo Labs.
+diff --git a/src/libraries/EventsLib.sol b/src/libraries/EventsLib.sol
+index f9dc967..862b344 100644
+--- a/src/libraries/EventsLib.sol
++++ b/src/libraries/EventsLib.sol
+@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
+ 
+ import {FlowCapsConfig} from "../interfaces/IPublicAllocator.sol";
+ 
+-import {IERC4626} from "../../lib/openzeppelin-contracts/contracts/interfaces/IERC4626.sol";
++import {IERC4626} from "openzeppelin-contracts/interfaces/IERC4626.sol";
+ 
+```
+
+_Showing first 100 of 117 lines. [View full diff on GitHub](https://github.com/euler-xyz/euler-earn/compare/773453b...master)_
+
+### euler-price-oracle @ `f52cb43b`
+
+**Contracts:** oracleRouterFactory
+
+- **Deployed from:** [`f52cb43b`](https://github.com/euler-xyz/euler-price-oracle/tree/f52cb43b)
+- **Compare to master:** [`f52cb43b...master`](https://github.com/euler-xyz/euler-price-oracle/compare/f52cb43b...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-swap @ `81cf6dc9`
+
+**Contracts:** eulerSwapV2Factory, eulerSwapV2Implementation, eulerSwapV2Periphery, eulerSwapV2ProtocolFeeConfig, eulerSwapV2Registry
+
+- **Deployed from:** [`81cf6dc9`](https://github.com/euler-xyz/euler-swap/tree/81cf6dc9)
+- **Compare to master:** [`81cf6dc9...master`](https://github.com/euler-xyz/euler-swap/compare/81cf6dc9...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### euler-vault-kit @ `422bf244`
+
+**Contracts:** eVaultFactory, eVaultImplementation, protocolConfig, sequenceRegistry
+
+- **Deployed from:** [`422bf244`](https://github.com/euler-xyz/euler-vault-kit/tree/422bf244)
+- **Compare to master:** [`422bf244...master`](https://github.com/euler-xyz/euler-vault-kit/compare/422bf244...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### evk-periphery @ `2b087370`
+
+**Contracts:** swapVerifier
+
+- **Deployed from:** [`2b087370`](https://github.com/euler-xyz/evk-periphery/tree/2b087370)
+- **Compare to master:** [`2b087370...master`](https://github.com/euler-xyz/evk-periphery/compare/2b087370...master)
+
+```diff
+diff --git a/src/Swaps/SwapVerifier.sol b/src/Swaps/SwapVerifier.sol
+index e4972629..4688cda3 100644
+--- a/src/Swaps/SwapVerifier.sol
++++ b/src/Swaps/SwapVerifier.sol
+@@ -2,18 +2,27 @@
+ 
+ pragma solidity ^0.8.0;
+ 
+-import {IEVault, IERC20} from "evk/EVault/IEVault.sol";
++import {IEVault} from "evk/EVault/IEVault.sol";
++import {TransferFromSender} from "./TransferFromSender.sol";
++import {IEVault, IERC4626} from "evk/EVault/IEVault.sol";
++import {SafeERC20, IERC20} from "openzeppelin-contracts/token/ERC20/utils/SafeERC20.sol";
+ 
+ /// @title SwapVerifier
+ /// @custom:security-contact security@euler.xyz
+ /// @author Euler Labs (https://www.eulerlabs.com/)
+-/// @notice Simple contract used to verify post swap conditions
++/// @notice Simple contract used to verify post swap conditions. Includes TransferFromSender helper for gas savings.
+ /// @dev This contract is the only trusted code in the EVK swap periphery
+-contract SwapVerifier {
++contract SwapVerifier is TransferFromSender {
+     error SwapVerifier_skimMin();
++    error SwapVerifier_depositMin();
+     error SwapVerifier_debtMax();
+     error SwapVerifier_pastDeadline();
+ 
++    /// @notice Contract constructor
++    /// @param evc Address of the EthereumVaultConnector contract
++    /// @param permit2 Address of the Permit2 contract
++    constructor(address evc, address permit2) TransferFromSender(evc, permit2) {}
++
+     /// @notice Verify results of a regular swap, when bought tokens are sent to the vault and skim for the buyer
+     /// @param vault The EVault to query
+     /// @param receiver Account to skim to
+@@ -23,7 +32,6 @@ contract SwapVerifier {
+     /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
+     function verifyAmountMinAndSkim(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
+         if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
+-        if (amountMin == 0) return;
+ 
+         uint256 cash = IEVault(vault).cash();
+         uint256 balance = IERC20(IEVault(vault).asset()).balanceOf(vault);
+@@ -35,6 +43,25 @@ contract SwapVerifier {
+         IEVault(vault).skim(type(uint256).max, receiver);
+     }
+ 
++    /// @notice Verify results of a regular swap, when bought tokens are sent to the verifier, and deposit for the buyer
++    /// @param vault The ERC4626 vault to deposit to
++    /// @param receiver Account to deposit for
++    /// @param amountMin Minimum amount of assets that should be available for deposit
++    /// @param deadline Timestamp after which the swap transaction is outdated
++    /// @dev Swapper contract will send bought assets to the verifier in certain situations.
++    /// @dev Calling this function is then necessary to perform slippage check and claim the output for the buyer
++    function verifyAmountMinAndDeposit(address vault, address receiver, uint256 amountMin, uint256 deadline) external {
++        if (deadline < block.timestamp) revert SwapVerifier_pastDeadline();
++
++        IERC20 asset = IERC20(IERC4626(vault).asset());
++        uint256 balance = asset.balanceOf(address(this));
++
++        if (balance < amountMin) revert SwapVerifier_depositMin();
++
++        SafeERC20.forceApprove(asset, vault, balance);
++        IERC4626(vault).deposit(balance, receiver);
++    }
++
+     /// @notice Verify results of a swap and repay operation, when debt is repaid down to a requested target
+     /// @param vault The EVault to query
+     /// @param account User account to query
+```
+
+### evk-periphery @ `392c7bd0`
+
+**Contracts:** eulOFTAdapter
+
+- **Deployed from:** [`392c7bd0`](https://github.com/euler-xyz/evk-periphery/tree/392c7bd0)
+- **Compare to master:** [`392c7bd0...master`](https://github.com/euler-xyz/evk-periphery/compare/392c7bd0...master)
+
+```diff
+diff --git a/src/ERC20/deployed/ERC20BurnableMintable.sol b/src/ERC20/deployed/ERC20BurnableMintable.sol
+index 82413624..19bb8e81 100644
+--- a/src/ERC20/deployed/ERC20BurnableMintable.sol
++++ b/src/ERC20/deployed/ERC20BurnableMintable.sol
+@@ -45,7 +45,7 @@ contract ERC20BurnableMintable is AccessControlEnumerable, ERC20Burnable, ERC20P
+     /// @notice Mints new tokens and assigns them to an account
+     /// @param _account The address that will receive the minted tokens
+     /// @param _amount The amount of tokens to mint
+-    function mint(address _account, uint256 _amount) external onlyRole(MINTER_ROLE) {
++    function mint(address _account, uint256 _amount) external virtual onlyRole(MINTER_ROLE) {
+         _mint(_account, _amount);
+     }
+```
+
+### fee-flow @ `4a419c94`
+
+**Contracts:** feeFlowController
+
+- **Deployed from:** [`4a419c94`](https://github.com/euler-xyz/fee-flow/tree/4a419c94)
+- **Compare to master:** [`4a419c94...master`](https://github.com/euler-xyz/fee-flow/compare/4a419c94...master)
+- **evk-periphery:** [`master`](https://github.com/euler-xyz/evk-periphery/tree/master)
+
+_No diff available - see GitHub compare link above._
+
+### reward-streams @ `9eb7b8a7`
+
+**Contracts:** balanceTracker
+
+- **Deployed from:** [`9eb7b8a7`](https://github.com/euler-xyz/reward-streams/tree/9eb7b8a7)
+- **Compare to master:** [`9eb7b8a7...master`](https://github.com/euler-xyz/reward-streams/compare/9eb7b8a7...master)
+- **evk-periphery:** [`deploy-swell`](https://github.com/euler-xyz/evk-periphery/tree/deploy-swell)
+
+_No diff available - see GitHub compare link above._
+


### PR DESCRIPTION
## Summary

Adds a `verify/` folder with contract verification reports for all production networks (339/359 contracts verified across 14 chains).

Each report shows:
- Deployment commit for every contract
- Source repo and evk-periphery reference
- File match count
- Diffs of any code changes since deployment (scoped to deployed files only)

The CI workflow is updated to automatically commit updated reports back to `verify/` after verification runs — only when reports actually change.

## What changes

- **New folder:** `verify/` with 19 markdown reports + README
- **Workflow update:** Added a "Commit reports" step at the end of the existing verification workflow. Only commits if reports differ from what's already in the repo.

## Networks covered

| Status | Networks |
|--------|----------|
| 100% verified | Mainnet, Arbitrum, Base, BSC, Avalanche, Swell, Sonic, Bob, Berachain, Unichain, Monad, TAC |
| Partial | Linea (25/26), Plasma (7/26) |